### PR TITLE
Fix CI issues on macOS 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,9 @@ jobs:
           (needs.format.result != 'success')
 
   test:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -55,6 +58,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@207a5a0786d0263d27c287c7bc6dd54fec8bed64
       - uses: julia-actions/julia-buildpkg@5484b0e27fa12452eb1deffe4fd40ff700c429b9
       - uses: julia-actions/julia-runtest@79a7e100883947123f8263c5f06e6c0ea3eb972f
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,25 @@ function with_extension(path, ext)
     return "$root.$ext"
 end
 
+# Update and precompile all project TOMLs when in CI.
+if get(ENV, "CI", "false") == "true"
+    for dir in ["integrations", "mimetypes"]
+        for (root, dirs, files) in walkdir(joinpath(@__DIR__, "examples", dir))
+            for each in files
+                if each == "Project.toml"
+                    manifest = joinpath(root, "Manifest.toml")
+                    if isfile(manifest)
+                        rm(manifest; force = true)
+                    end
+                    run(
+                        `$(Base.julia_cmd()) --project=$root -e 'push!(LOAD_PATH, "@stdlib"); import Pkg; Pkg.update()'`,
+                    )
+                end
+            end
+        end
+    end
+end
+
 @testset "QuartoNotebookRunner" begin
     @testset "socket server" begin
         cd(@__DIR__) do


### PR DESCRIPTION
The worker processes running the notebooks appear to stall on macOS 1.6 when precompiling some of the more costly notebook project environments. Avoid that by running the precompilation separately prior to starting the tests.

Adds the cache action to try to save as much of that precompilation work as possible.