### PR TITLE
fix: run! errors if output is a standalone file

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -99,7 +99,10 @@ end
 
 function _check_output_dst(s::AbstractString)
     dir = dirname(s)
-    isdir(dir) || throw(ArgumentError("directory does not exist: $(dir)"))
+    if !isdir(dir)
+        _dir = dirname(joinpath(pwd(), s))
+        isdir(_dir) || throw(ArgumentError("directory does not exist: $(dir)"))
+    end
     return nothing
 end
 _check_output_dst(::Any) = nothing


### PR DESCRIPTION
Right now the `run!` function errors on the README instructions.

The idea here is to add an `if` to check it the `dirname` of the `joinpath(pwd(), output)` is a dir instead of throwing error straight away.