### PR TITLE
Fix package integration hooks logic

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -184,7 +184,7 @@ function raw_markdown_chunks(path::String)
             )
         end
 
-        frontmatter = _recursive_merge(CommonMark.frontmatter(ast), default_frontmatter())
+        frontmatter = _recursive_merge(default_frontmatter(), CommonMark.frontmatter(ast))
 
         return raw_chunks, frontmatter
     else

--- a/test/examples/integrations/CairoMakie.qmd
+++ b/test/examples/integrations/CairoMakie.qmd
@@ -1,5 +1,7 @@
 ---
 title: CairoMakie integration
+fig-width: 4
+fig-height: 3
 ---
 
 ```{julia}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -831,4 +831,35 @@ end
             end
         end
     end
+
+    @testset "package integration hooks" begin
+        env_dir = joinpath(@__DIR__, "examples/integrations/CairoMakie")
+        content = read(joinpath(@__DIR__, "examples/integrations/CairoMakie.qmd"), String)
+        mktempdir() do dir
+            cd(dir) do
+                server = QuartoNotebookRunner.Server()
+
+                cp(env_dir, joinpath(dir, "CairoMakie"))
+                write("CairoMakie.qmd", content)
+
+                json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")
+
+                image_png = json.cells[end].outputs[1].metadata["image/png"]
+                @test image_png.width == 768
+                @test image_png.height == 576
+
+                content = replace(content, "fig-width: 4" => "fig-width: 8")
+                content = replace(content, "fig-height: 3" => "fig-height: 6")
+                write("CairoMakie.qmd", content)
+
+                json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")
+
+                image_png = json.cells[end].outputs[1].metadata["image/png"]
+                @test image_png.width == 1536
+                @test image_png.height == 1152
+
+                close!(server)
+            end
+        end
+    end
 end


### PR DESCRIPTION
Only attempt to rerun hooks for packages that have actually already been loaded, otherwise version checks will fail since the package isn't actually loaded. Cache package version as an optimisation.