### PR TITLE
Adjust precompile workload to avoid warnings

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,9 +1,10 @@
 PrecompileTools.@setup_workload begin
+    notebook = joinpath(@__DIR__, "..", "test", "examples", "cell_types.qmd")
+    script = joinpath(@__DIR__, "..", "test", "examples", "cell_types.jl")
+    results = Dict{String,@NamedTuple{error::Bool, data::Vector{UInt8}}}()
     PrecompileTools.@compile_workload begin
-        server = Server()
-        notebook = joinpath(@__DIR__, "..", "test", "examples", "cell_types.qmd")
-        run!(server, notebook; output = IOBuffer(), showprogress = false)
-        run!(server, notebook; output = IOBuffer(), showprogress = false)
-        close!(server)
+        raw_text_chunks(notebook)
+        raw_text_chunks(script)
+        process_results(results)
     end
 end


### PR DESCRIPTION
1.10 during precompilation has some warnings due to tasks hanging. This is due to the `Malt` workers. Skip these parts of the precompilation so that we don't run into that warning.

Fixes #8.