### PR TITLE
Fix CairoMakie behavior for figure width and dpi settings

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -339,11 +339,7 @@ function raw_script_chunks(path::String)
 end
 
 function default_frontmatter()
-    # TODO: work out what the real defaults should be.
     Dict{String,Any}(
-        "fig-width" => 4,
-        "fig-height" => 3,
-        "fig-dpi" => 96,
         "fig-format" => "png",
         "julia" => Dict{String,Any}("exeflags" => []),
     )

--- a/src/server.jl
+++ b/src/server.jl
@@ -339,10 +339,7 @@ function raw_script_chunks(path::String)
 end
 
 function default_frontmatter()
-    Dict{String,Any}(
-        "fig-format" => "png",
-        "julia" => Dict{String,Any}("exeflags" => []),
-    )
+    Dict{String,Any}("fig-format" => "png", "julia" => Dict{String,Any}("exeflags" => []))
 end
 
 """

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -327,8 +327,12 @@ function worker_init(f::File)
             # only change Makie theme if sizes are set, if only one is set, pick an aspect ratio of 4/3
             # which might be more user-friendly than throwing an error
             if fm.fig_width_inch !== nothing || fm.fig_height_inch !== nothing
-                _width_inch = @something(fm.fig_width_inch, fm.fig_height_inch * 4 / 3)
-                _height_inch = @something(fm.fig_height_inch, fm.fig_width_inch / 4 * 3)
+                _width_inch =
+                    fm.fig_width_inch !== nothing ? fm.fig_width_inch :
+                    fm.fig_height_inch * 4 / 3
+                _height_inch =
+                    fm.fig_height_inch !== nothing ? fm.fig_height_inch :
+                    fm.fig_width_inch / 4 * 3
 
                 # Convert inches to CSS pixels or device-independent pixels which Makie
                 # uses as the base unit for its plots when used with default settings.
@@ -357,8 +361,12 @@ function worker_init(f::File)
             if fm.fig_width_inch !== nothing || fm.fig_height_inch !== nothing
                 # if only width or height is set, pick an aspect ratio of 4/3
                 # which might be more user-friendly than throwing an error
-                _width_inch = @something(fm.fig_width_inch, fm.fig_height_inch * 4 / 3)
-                _height_inch = @something(fm.fig_height_inch, fm.fig_width_inch / 4 * 3)
+                _width_inch =
+                    fm.fig_width_inch !== nothing ? fm.fig_width_inch :
+                    fm.fig_height_inch * 4 / 3
+                _height_inch =
+                    fm.fig_height_inch !== nothing ? fm.fig_height_inch :
+                    fm.fig_width_inch / 4 * 3
                 fig_width_px = _width_inch * 96
                 fig_height_px = _height_inch * 96
                 size_kwargs = Dict{Symbol,Any}(:size => (fig_width_px, fig_height_px))

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -365,11 +365,9 @@ function worker_init(f::File)
             else
                 size_kwargs = Dict{Symbol,Any}()
             end
-                
+
             if fm.fig_dpi !== nothing
-                dpi_kwargs = Dict{Symbol,Any}(
-                    :dpi => fm.fig_dpi,
-                )
+                dpi_kwargs = Dict{Symbol,Any}(:dpi => fm.fig_dpi)
             else
                 dpi_kwargs = Dict{Symbol,Any}()
             end
@@ -377,11 +375,7 @@ function worker_init(f::File)
             if (_pkg_version(pkgid) < v"1.28.1") && (fm.fig_format == "pdf")
                 Plots.gr(; size_kwargs..., fmt = :png, dpi_kwargs...)
             else
-                Plots.gr(; 
-                    size_kwargs...,
-                    fmt = fm.fig_format,
-                    dpi_kwargs...,
-                )
+                Plots.gr(; size_kwargs..., fmt = fm.fig_format, dpi_kwargs...)
             end
             return nothing
         end

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -275,15 +275,13 @@ function worker_init(f::File)
         function _frontmatter()
             fm = FRONTMATTER[]
 
-            fig_width_inch = fm["fig-width"]
-            fig_height_inch = fm["fig-height"]
+            fig_width_inch = get(fm, "fig-width", nothing)
+            fig_height_inch = get(fm, "fig-height", nothing)
             fig_format = fm["fig-format"]
-            fig_dpi = fm["fig-dpi"]
+            fig_dpi = get(fm, "fig-dpi", nothing)
 
             if fig_format == "retina"
                 fig_format = "svg"
-            elseif fig_format == "pdf"
-                fig_dpi = 96
             end
 
             return (; fig_width_inch, fig_height_inch, fig_format, fig_dpi)
@@ -308,28 +306,40 @@ function worker_init(f::File)
 
         function _CairoMakie_hook(pkgid::Base.PkgId, CairoMakie::Module)
             fm = _frontmatter()
-            px_per_unit = fm.fig_dpi / 96
-            pt_per_unit = 0.75 # this is the default in Makie, too, because 1 CSS px == 0.75 pt
-            if fm.fig_format == "pdf"
-                CairoMakie.activate!(; type = "png", px_per_unit, pt_per_unit)
+            if fm.fig_dpi !== nothing
+                kwargs = Dict{Symbol,Any}(
+                    :px_per_unit => fm.fig_dpi / 96,
+                    :pt_per_unit => 0.75, # this is the default in Makie, too, because 1 CSS px == 0.75 pt
+                )
             else
-                CairoMakie.activate!(; type = fm.fig_format, px_per_unit, pt_per_unit)
+                kwargs = Dict{Symbol,Any}()
+            end
+            if fm.fig_format == "pdf"
+                CairoMakie.activate!(; type = "png", kwargs...)
+            else
+                CairoMakie.activate!(; type = fm.fig_format, kwargs...)
             end
         end
         _CairoMakie_hook(::Any...) = nothing
 
         function _Makie_hook(pkgid::Base.PkgId, Makie::Module)
             fm = _frontmatter()
+            # only change Makie theme if sizes are set, if only one is set, pick an aspect ratio of 4/3
+            # which might be more user-friendly than throwing an error
+            if fm.fig_width_inch !== nothing || fm.fig_height_inch !== nothing
+                _width_inch = @something(fm.fig_width_inch, fm.fig_height_inch * 4 / 3)
+                _height_inch = @something(fm.fig_height_inch, fm.fig_width_inch / 4 * 3)
 
-            # Convert inches to CSS pixels or device-independent pixels which Makie
-            # uses as the base unit for its plots when used with default settings.
-            fig_width = fm.fig_width_inch * 96
-            fig_height = fm.fig_height_inch * 96
+                # Convert inches to CSS pixels or device-independent pixels which Makie
+                # uses as the base unit for its plots when used with default settings.
+                fig_width = _width_inch * 96
+                fig_height = _height_inch * 96
 
-            if _pkg_version(pkgid) < v"0.20"
-                Makie.update_theme!(; resolution = (fig_width, fig_height))
-            else
-                Makie.update_theme!(; size = (fig_width, fig_height))
+                if _pkg_version(pkgid) < v"0.20"
+                    Makie.update_theme!(; resolution = (fig_width, fig_height))
+                else
+                    Makie.update_theme!(; size = (fig_width, fig_height))
+                end
             end
         end
         _Makie_hook(::Any...) = nothing
@@ -343,16 +353,34 @@ function worker_init(f::File)
             # you get an image whose size (with rounding error) matches the numbers set for size while
             # this should happen with 96. But we cannot solve that discrepancy here. So we just forward
             # the values as given.
-            fig_width_px = fm.fig_width_inch * 96
-            fig_height_px = fm.fig_height_inch * 96
+
+            if fm.fig_width_inch !== nothing || fm.fig_height_inch !== nothing
+                # if only width or height is set, pick an aspect ratio of 4/3
+                # which might be more user-friendly than throwing an error
+                _width_inch = @something(fm.fig_width_inch, fm.fig_height_inch * 4 / 3)
+                _height_inch = @something(fm.fig_height_inch, fm.fig_width_inch / 4 * 3)
+                fig_width_px = _width_inch * 96
+                fig_height_px = _height_inch * 96
+                size_kwargs = Dict{Symbol,Any}(:size => (fig_width_px, fig_height_px))
+            else
+                size_kwargs = Dict{Symbol,Any}()
+            end
+                
+            if fm.fig_dpi !== nothing
+                dpi_kwargs = Dict{Symbol,Any}(
+                    :dpi => fm.fig_dpi,
+                )
+            else
+                dpi_kwargs = Dict{Symbol,Any}()
+            end
 
             if (_pkg_version(pkgid) < v"1.28.1") && (fm.fig_format == "pdf")
-                Plots.gr(size = (fig_width_px, fig_height_px), fmt = :png, dpi = fm.fig_dpi)
+                Plots.gr(; size_kwargs..., fmt = :png, dpi_kwargs...)
             else
-                Plots.gr(
-                    size = (fig_width_px, fig_height_px),
+                Plots.gr(; 
+                    size_kwargs...,
                     fmt = fm.fig_format,
-                    dpi = fm.fig_dpi,
+                    dpi_kwargs...,
                 )
             end
             return nothing

--- a/test/examples/integrations/CairoMakie.qmd
+++ b/test/examples/integrations/CairoMakie.qmd
@@ -2,6 +2,7 @@
 title: CairoMakie integration
 fig-width: 4
 fig-height: 3
+fig-dpi: 150
 ---
 
 ```{julia}

--- a/test/examples/integrations/Plots.qmd
+++ b/test/examples/integrations/Plots.qmd
@@ -1,5 +1,8 @@
 ---
 title: Plots integration
+fig-width: 4
+fig-height: 3
+fig-dpi: 150
 ---
 
 ```{julia}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -863,10 +863,11 @@ end
                     # handle Windows
                     content_unified = replace(content, "\r\n" => "\n")
                     _content =
-                        preamble === nothing ? content_unified : replace(content_unified, """
-                                                             fig-width: 4
-                                                             fig-height: 3
-                                                             fig-dpi: 150""" => preamble)
+                        preamble === nothing ? content_unified :
+                        replace(content_unified, """
+                    fig-width: 4
+                    fig-height: 3
+                    fig-dpi: 150""" => preamble)
 
                     write("CairoMakie.qmd", _content)
                     json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -861,13 +861,10 @@ end
 
                 function png_metadata(preamble = nothing)
                     _content =
-                        preamble === nothing ?
-                        content :
-                        replace(content, """
-                            fig-width: 4
-                            fig-height: 3
-                            fig-dpi: 150""" => preamble
-                        )
+                        preamble === nothing ? content : replace(content, """
+                                                             fig-width: 4
+                                                             fig-height: 3
+                                                             fig-dpi: 150""" => preamble)
 
                     write("CairoMakie.qmd", _content)
                     json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")
@@ -881,22 +878,19 @@ end
                 metadata = png_metadata("""
                     fig-width: 8
                     fig-height: 6
-                    fig-dpi: 300"""
-                )
+                    fig-dpi: 300""")
                 @test metadata.width == 8 * 300
                 @test metadata.height == 6 * 300
 
                 metadata = png_metadata("""
                     fig-width: 5
-                    fig-dpi: 100"""
-                )
+                    fig-dpi: 100""")
                 @test metadata.width == 5 * 100
                 @test metadata.height == round(5 / 4 * 3 * 100)
 
                 metadata = png_metadata("""
                     fig-height: 5
-                    fig-dpi: 100"""
-                )
+                    fig-dpi: 100""")
                 @test metadata.height == 5 * 100
                 @test metadata.width == round(5 / 3 * 4 * 100)
 
@@ -904,11 +898,9 @@ end
                 # but for the dpi-only test we can check that doubling the
                 # dpi doubles image dimensions, whatever they are
                 metadata_100dpi = png_metadata("""
-                    fig-dpi: 96"""
-                )
+                    fig-dpi: 96""")
                 metadata_200dpi = png_metadata("""
-                    fig-dpi: 192"""
-                )
+                    fig-dpi: 192""")
                 @test 2 * metadata_100dpi.height == metadata_200dpi.height
                 @test 2 * metadata_100dpi.width == metadata_200dpi.width
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -904,6 +904,16 @@ end
                 @test 2 * metadata_100dpi.height == metadata_200dpi.height
                 @test 2 * metadata_100dpi.width == metadata_200dpi.width
 
+                # same logic for width and height only
+                metadata_single = png_metadata("""
+                    fig-width: 3
+                    fig-height: 2""")
+                metadata_double = png_metadata("""
+                    fig-width: 6
+                    fig-height: 4""")
+                @test 2 * metadata_single.height == metadata_double.height
+                @test 2 * metadata_single.width == metadata_double.width
+
                 close!(server)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -485,7 +485,7 @@ end
             cells = json["cells"]
             cell = cells[6]
             @test cell["outputs"][1]["metadata"]["image/png"] ==
-                  Dict("width" => 768, "height" => 576)
+                  Dict("width" => 4 * 96, "height" => 3 * 96)
         end
         file(joinpath("integrations", "Plots")) do json
             cells = json["cells"]
@@ -862,18 +862,18 @@ end
                 json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")
 
                 image_png = json.cells[end].outputs[1].metadata["image/png"]
-                @test image_png.width == 768
-                @test image_png.height == 576
+                @test image_png.width == 4 * 96
+                @test image_png.height == 3 * 96
 
                 content = replace(content, "fig-width: 4" => "fig-width: 8")
-                content = replace(content, "fig-height: 3" => "fig-height: 6")
+                content = replace(content, "fig-height: 3" => "fig-height: 6\nfig-dpi: 300")
                 write("CairoMakie.qmd", content)
 
                 json = QuartoNotebookRunner.run!(server, "CairoMakie.qmd")
 
                 image_png = json.cells[end].outputs[1].metadata["image/png"]
-                @test image_png.width == 1536
-                @test image_png.height == 1152
+                @test image_png.width == 8 * 300
+                @test image_png.height == 6 * 300
 
                 close!(server)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -860,8 +860,10 @@ end
                 cp(env_dir, joinpath(dir, "CairoMakie"))
 
                 function png_metadata(preamble = nothing)
+                    # handle Windows
+                    content_unified = replace(content, "\r\n" => "\n")
                     _content =
-                        preamble === nothing ? content : replace(content, """
+                        preamble === nothing ? content_unified : replace(content_unified, """
                                                              fig-width: 4
                                                              fig-height: 3
                                                              fig-dpi: 150""" => preamble)


### PR DESCRIPTION
Copying a message from Slack:

> the way it works in Makie 0.20 is that we mostly treat the unit in px_per_unit as the CSS px, or device independent pixel. The px in px_per_unit is then the real image pixel. When a quarto document requests some dpi which means dots per inch, or effectively pixels per inch these days, then the pixels in that is referring to real image pixels. And inch is obviously a real-world metric that doesn't change, but so is the CSS pixel, which has a fixed conversion to inches.
So, we want to convert the fig_width and fig_height which are given in inches to CSS pixels. This is done by multiplying with 96. Then these numbers should be the Makie figure size. The px_per_unit value we need to set to achieve the given dpi we can calculate similarly. 300 dots per inch == 300 / 96 dots per CSS pixel == 3.125 px_per_unit