### PR TITLE
Pin `Plots` version

### DIFF
--- a/test/examples/integrations/Plots/Project.toml
+++ b/test/examples/integrations/Plots/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[compat]
+Plots = "=1.39.0"


### PR DESCRIPTION
There appears to be some breakage on the most recent version of this package that is causing the REPL to hang, or segfault on tests. Just pin its version for now.