### PR TITLE
Project frontmatter

### DIFF
--- a/src/socket.jl
+++ b/src/socket.jl
@@ -14,7 +14,7 @@ Message schema:
 ```json
 {
     type: "run" | "close" | "stop"
-    content: string
+    content: string | { file: string, options: string | { ... } }
 }
 ```
 
@@ -90,11 +90,11 @@ end
 
 function _handle_response(
     notebooks::Server,
-    request::@NamedTuple{type::String, content::String},
+    request::@NamedTuple{type::String, content::Union{String,Dict{String,Any}}},
 )
     @debug "debugging" request notebooks = collect(keys(notebooks.workers))
     type = request.type
-    file = request.content
+    file = _get_file(request.content)
 
     type in ("close", "run") || return _log_error("Unknown request type: $type")
 
@@ -120,8 +120,9 @@ function _handle_response(
     # Running:
 
     if type == "run"
+        options = _get_options(request.content)
         try
-            return (; notebook = run!(notebooks, file))
+            return (; notebook = run!(notebooks, file; options))
         catch error
             return _log_error("Failed to run notebook: $file", error, catch_backtrace())
         end
@@ -141,8 +142,23 @@ function _log_error(message)
 end
 
 # TODO: check what the message schema is for this.
-_read_json(data) = JSON3.read(data, @NamedTuple{type::String, content::String})
+_read_json(data) = JSON3.read(
+    data,
+    @NamedTuple{type::String, content::Union{String,Union{String,Dict{String,Any}}}}
+)
 _write_json(socket, data) = write(socket, JSON3.write(data), "\n")
+
+function _get_file(content::Dict)
+    if haskey(content, "file")
+        return content["file"]
+    else
+        error("No 'file' key in content: $(repr(content))")
+    end
+end
+_get_file(content::String) = content
+
+_get_options(content::Dict) = get(Dict{String,Any}, content, "options")
+_get_options(::String) = Dict{String,Any}()
 
 # Compat:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -877,31 +877,33 @@ end
                 cp(joinpath(@__DIR__, "examples/mimetypes"), joinpath(dir, "mimetypes"))
                 server = QuartoNotebookRunner.Server()
                 write("mimetypes.qmd", content)
-                ipynb = "mimetypes.ipynb"
                 options = Dict{String,Any}("metadata" => Dict{String,Any}("fig-dpi" => 100))
-                QuartoNotebookRunner.run!(server, "mimetypes.qmd"; output = ipynb, options)
-                json = JSON3.read(ipynb)
+                json = QuartoNotebookRunner.run!(
+                    server,
+                    "mimetypes.qmd";
+                    options,
+                    showprogress = false,
+                )
                 cell = json.cells[6]
                 metadata = cell.outputs[1].metadata["image/png"]
-                @test metadata["width"] == 625
-                @test metadata["height"] == 469
+                @test metadata.width == 625
+                @test metadata.height == 469
 
                 options_file = "temp_options.json"
                 open(options_file, "w") do io
                     JSON3.pretty(io, options)
                 end
 
-                QuartoNotebookRunner.run!(
+                json = QuartoNotebookRunner.run!(
                     server,
                     "mimetypes.qmd";
-                    output = ipynb,
                     options = options_file,
+                    showprogress = false,
                 )
-                json = JSON3.read(ipynb)
                 cell = json.cells[6]
                 metadata = cell.outputs[1].metadata["image/png"]
-                @test metadata["width"] == 625
-                @test metadata["height"] == 469
+                @test metadata.width == 625
+                @test metadata.height == 469
             end
         end
 


### PR DESCRIPTION
Allow passing extra frontmatter into `run!` and into the socket server.

The `A way to share YAML configuration across multiple documents.` part of #16.