### PR TITLE
Improve stability of tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         version:
           - "1.6"

--- a/src/server.jl
+++ b/src/server.jl
@@ -601,7 +601,7 @@ function run!(
 end
 
 """
-    render(file::AbstractString; output::Union{AbstractString,IO,Nothing} = nothing)
+    render(file::AbstractString; output::Union{AbstractString,IO,Nothing} = nothing, showprogress::Bool = true)
 
 Render the notebook in `file` and write the results to `output`. Uses a similar
 API to `run!` but does not keep the file loaded in a server and shuts down
@@ -609,9 +609,13 @@ immediately after rendering. This means that the user pays the full cost of
 initial startup each time they render a notebook. Prefer `run!` if you are going
 to be rendering the same notebook multiple times iteratively.
 """
-function render(file::AbstractString; output::Union{AbstractString,IO,Nothing} = nothing)
+function render(
+    file::AbstractString;
+    output::Union{AbstractString,IO,Nothing} = nothing,
+    showprogress::Bool = true,
+)
     server = Server()
-    run!(server, file; output = output)
+    run!(server, file; output, showprogress)
     close!(server, file)
 end
 


### PR DESCRIPTION
Removing use of `showprogress = true` appears to be the main factor here. Also reduce the number of `mktempdir` calls might be involved.