### PR TITLE
Add additional `metadata` to `ipynb` output

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -86,6 +86,11 @@ function evaluate!(
         cells = evaluate_raw_cells!(f, raw_chunks, merged_frontmatter; showprogress)
         data = (
             metadata = (
+                kernelspec = (
+                    display_name = "Julia $(VERSION)",
+                    language = "julia",
+                    name = "julia-$(VERSION)",
+                ),
                 kernel_info = (name = "julia",),
                 language_info = (
                     name = "julia",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,9 @@ end
         @test json["metadata"]["language_info"]["version"] == "$VERSION"
         @test json["metadata"]["language_info"]["codemirror_mode"] == "julia"
         @test json["metadata"]["kernel_info"]["name"] == "julia"
+        @test startswith(json["metadata"]["kernelspec"]["name"], "julia")
+        @test startswith(json["metadata"]["kernelspec"]["display_name"], "Julia")
+        @test json["metadata"]["kernelspec"]["language"] == "julia"
     end
     tests = let
         tests = Dict()


### PR DESCRIPTION
Fixes #21, correct syntax highlighting of Julia code blocks.