### PR TITLE
Allow setting `error` to control reporting of cell errors

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 NodeJS_18_jll = "c1e1d063-8311-5f52-a749-c7b05e91ae37"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 quarto_jll = "b7163347-bfae-5fd9-aba4-19f139889d78"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,10 @@ if get(ENV, "CI", "false") == "true"
 end
 
 @testset "QuartoNotebookRunner" begin
+
+    include("testsets/error_configuration/01.jl")
+    include("testsets/error_configuration/02.jl")
+
     @testset "socket server" begin
         cd(@__DIR__) do
             node = NodeJS_18_jll.node()

--- a/test/testsets/error_configuration/01.jl
+++ b/test/testsets/error_configuration/01.jl
@@ -1,0 +1,33 @@
+using Logging, Test, QuartoNotebookRunner
+
+@testset "error_configuration/01" begin
+    server = Server()
+
+    test_logger = Test.TestLogger()
+    with_logger(test_logger) do
+        qmd = joinpath(@__DIR__, "01.qmd")
+        @test_throws ErrorException run!(server, qmd)
+    end
+
+    @test length(test_logger.logs) == 3
+
+    log = test_logger.logs[1]
+    @test log.level == Logging.Error
+    @test log.message == "stopping notebook evaluation due to unexpected cell error."
+    @test endswith(log.kwargs[:file], "01.qmd:9")
+    @test occursin("no method matching", string(log.kwargs[:traceback]))
+
+    log = test_logger.logs[2]
+    @test log.level == Logging.Error
+    @test log.message == "stopping notebook evaluation due to unexpected cell error."
+    @test endswith(log.kwargs[:file], "01.qmd:13")
+    @test occursin("integer division error", string(log.kwargs[:traceback]))
+
+    log = test_logger.logs[3]
+    @test log.level == Logging.Error
+    @test log.message == "stopping notebook evaluation due to unexpected `show` error."
+    @test endswith(log.kwargs[:file], "01.qmd:31")
+    @test occursin("T failed to show.", string(log.kwargs[:traceback]))
+
+    close!(server)
+end

--- a/test/testsets/error_configuration/01.qmd
+++ b/test/testsets/error_configuration/01.qmd
@@ -1,0 +1,35 @@
+---
+title: Error configuration 1
+execute:
+    error: false
+---
+
+Disallow errors globally in this notebook.
+
+```{julia}
+1 + ""
+```
+
+```{julia}
+div(1, 0)
+```
+
+Allow the following cells to error.
+
+```{julia}
+#| error: true
+1 + ""
+```
+
+```{julia}
+#| error: true
+div(1, 0)
+```
+
+A `Base.show` error. These take a different code path internally.
+
+```{julia}
+struct T end
+Base.show(io::IO, ::T) = error("T failed to show.")
+T()
+```

--- a/test/testsets/error_configuration/02.jl
+++ b/test/testsets/error_configuration/02.jl
@@ -1,0 +1,27 @@
+using Logging, Test, QuartoNotebookRunner
+
+@testset "error_configuration/02" begin
+    server = Server()
+
+    test_logger = Test.TestLogger()
+    with_logger(test_logger) do
+        qmd = joinpath(@__DIR__, "02.qmd")
+        @test_throws ErrorException run!(server, qmd)
+    end
+
+    @test length(test_logger.logs) == 2
+
+    log = test_logger.logs[1]
+    @test log.level == Logging.Error
+    @test log.message == "stopping notebook evaluation due to unexpected cell error."
+    @test endswith(log.kwargs[:file], "02.qmd:9")
+    @test occursin("no method matching", string(log.kwargs[:traceback]))
+
+    log = test_logger.logs[2]
+    @test log.level == Logging.Error
+    @test log.message == "stopping notebook evaluation due to unexpected cell error."
+    @test endswith(log.kwargs[:file], "02.qmd:14")
+    @test occursin("integer division error", string(log.kwargs[:traceback]))
+
+    close!(server)
+end

--- a/test/testsets/error_configuration/02.qmd
+++ b/test/testsets/error_configuration/02.qmd
@@ -1,0 +1,25 @@
+---
+title: Error configuration 2
+---
+
+Allow errors globally in this notebook.
+
+Disallow the following two cells to error.
+
+```{julia}
+#| error: false
+1 + ""
+```
+
+```{julia}
+#| error: false
+div(1, 0)
+```
+
+```{julia}
+1 + ""
+```
+
+```{julia}
+div(1, 0)
+```


### PR DESCRIPTION
In frontmatter under the `execute` key and within cells as the `error` key.