### PR TITLE
Add support for suppressing output via `;`

### DIFF
--- a/src/worker.jl
+++ b/src/worker.jl
@@ -87,9 +87,11 @@ function worker_init(f::File)
             line::Integer,
             cell_options::AbstractDict,
         )
-            captured =
-                Base.@invokelatest include_str(WORKSPACE[], code; file = file, line = line)
-            results = Base.@invokelatest render_mimetypes(captured.value, cell_options)
+            captured = Base.@invokelatest include_str(WORKSPACE[], code; file, line)
+            results = Base.@invokelatest render_mimetypes(
+                REPL.ends_with_semicolon(code) ? nothing : captured.value,
+                cell_options,
+            )
             return (;
                 results,
                 output = captured.output,

--- a/test/testsets/semicolons.jl
+++ b/test/testsets/semicolons.jl
@@ -1,0 +1,32 @@
+include("../utilities/prelude.jl")
+
+@testset "Semicolons" begin
+    mktempdir() do dir
+        content = """
+        ---
+        title: "Semicolons"
+        ---
+
+        ```{julia}
+        variable = 1;
+        ```
+
+        ```{julia}
+        variable
+        ```
+        """
+        path = joinpath(dir, "notebook.qmd")
+        write(path, content)
+
+        server = Server()
+        json = run!(server, path; showprogress = false)
+
+        cell = json.cells[2]
+        @test isempty(cell.outputs[1].data)
+
+        cell = json.cells[4]
+        @test cell.outputs[1].data["text/plain"] == "1"
+
+        close!(server)
+    end
+end


### PR DESCRIPTION
To match the behaviour of the Julia REPL. This is an alternative to the `#| output: false` cell option.