### PR TITLE
Fix #15, inline code

### DIFF
--- a/src/worker.jl
+++ b/src/worker.jl
@@ -85,7 +85,7 @@ function worker_init(f::File)
             code::AbstractString,
             file::AbstractString,
             line::Integer,
-            cell_options::AbstractDict,
+            cell_options::AbstractDict = Dict{String,Any}(),
         )
             captured = Base.@invokelatest include_str(WORKSPACE[], code; file, line)
             results = Base.@invokelatest render_mimetypes(

--- a/test/testsets/inline_code.jl
+++ b/test/testsets/inline_code.jl
@@ -1,0 +1,65 @@
+include("../utilities/prelude.jl")
+
+@testset "Inline code" begin
+    mktempdir() do dir
+        qmd = joinpath(dir, "inline_code.qmd")
+        write(
+            qmd,
+            """
+            ---
+            title: "Inline code"
+            ---
+
+            ```{julia}
+            a = 1
+            ```
+
+            Some variables `{julia} a + 1`.
+
+            ```{julia}
+            struct Custom
+                value
+            end
+            Base.show(io::IO, ::MIME"text/markdown", c::Custom) = print(io, "*\$(c.value)*")
+            ```
+
+            Some custom markdown MIME type output `{julia} Custom("markdown")`.
+
+            ```{julia}
+            b = Text("*placeholder*")
+            ```
+
+            Some `Text` objects *`{julia} b`*. Escaped markdown syntax.
+
+            ```{julia}
+            c = "*placeholder*"
+            ```
+
+            Some plain `String`s `{julia} c`. Escaped markdown syntax.
+
+            > # A more complex expression `{julia} round(Int, 1.5)`.
+            """,
+        )
+
+        server = Server()
+        json = run!(server, qmd; showprogress = false)
+
+        cells = json.cells
+
+        cell = cells[3]
+        @test any(contains("Some variables 2."), cell.source)
+
+        cell = cells[5]
+        @test any(
+            contains("Some custom markdown MIME type output *markdown*."),
+            cell.source,
+        )
+
+        cell = cells[7]
+        @test any(contains("Some `Text` objects *\\*placeholder\\**."), cell.source)
+
+        cell = cells[9]
+        @test any(contains("Some plain `String`s \"\\*placeholder\\*\"."), cell.source)
+        @test any(contains("A more complex expression 2."), cell.source)
+    end
+end


### PR DESCRIPTION
The behaviour of `AbstractString` printing and escaping needs to be decided on here. Worth seeing what the other languages actually do.