### PR TITLE
Add `isopen` and `isready` commands to server protocol

### DIFF
--- a/test/testsets/socket_server/client.js
+++ b/test/testsets/socket_server/client.js
@@ -9,6 +9,8 @@ function handle() {
     const run = (file) => toJSON({ type: 'run', content: file });
     const close = (file) => toJSON({ type: 'close', content: file || '' });
     const stop = () => toJSON({ type: 'stop', content: '' });
+    const isopen = (file) => toJSON({ type: 'isopen', content: file });
+    const isready = () => toJSON({ type: 'isready', content: '' });
 
     const notebook = (arg) => {
         if (arg) {
@@ -27,6 +29,10 @@ function handle() {
             return close(notebook(arg));
         case 'stop':
             return stop();
+        case 'isopen':
+            return isopen(notebook(arg));
+        case 'isready':
+            return isready();
         default:
             throw new Error('Invalid command.');
     }

--- a/test/testsets/socket_server/socket_server.jl
+++ b/test/testsets/socket_server/socket_server.jl
@@ -11,20 +11,31 @@ include("../../utilities/prelude.jl")
 
         cell_types = "../../examples/cell_types.qmd"
 
-        d1 = json(`$node $client $port run $(cell_types)`)
-        @test length(d1["notebook"]["cells"]) == 6
+        @test json(`$node $client $port isready`)
+
+        d1 = json(`$node $client $port isopen $(cell_types)`)
+        @test d1 == false
 
         d2 = json(`$node $client $port run $(cell_types)`)
-        @test d1 == d2
+        @test length(d2["notebook"]["cells"]) == 6
 
-        d3 = json(`$node $client $port close $(cell_types)`)
-        @test d3["status"] == true
+        d3 = json(`$node $client $port isopen $(cell_types)`)
+        @test d3 == true
 
         d4 = json(`$node $client $port run $(cell_types)`)
-        @test d1 == d4
+        @test d2 == d4
 
-        d5 = json(`$node $client $port stop`)
-        @test d5["message"] == "Server stopped."
+        d5 = json(`$node $client $port close $(cell_types)`)
+        @test d5["status"] == true
+
+        d6 = json(`$node $client $port isopen $(cell_types)`)
+        @test d6 == false
+
+        d7 = json(`$node $client $port run $(cell_types)`)
+        @test d2 == d7
+
+        d8 = json(`$node $client $port stop`)
+        @test d8["message"] == "Server stopped."
 
         wait(server)
     end


### PR DESCRIPTION
`isopen` can be used to check that a file already has a worker opened for it, which can then be `close`d if desired. The `isready` command is just to have something for quarto to establish that the server is functioning at all, before sending further commands to it.

Fixes https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/39