### PR TITLE
Support `julia.env` frontmatter

### DIFF
--- a/test/examples/env_and_exeflags.qmd
+++ b/test/examples/env_and_exeflags.qmd
@@ -1,0 +1,13 @@
+---
+title: env
+julia:
+    env: ["FOO=BAR"]
+---
+
+```{julia}
+ENV["FOO"]
+```
+
+```{julia}
+printstyled("red"; color = :red)
+```

--- a/test/testsets/env_and_exeflags.jl
+++ b/test/testsets/env_and_exeflags.jl
@@ -1,0 +1,25 @@
+include("../utilities/prelude.jl")
+
+test_example(joinpath(@__DIR__, "../examples/env_and_exeflags.qmd")) do json
+    cells = json["cells"]
+    @test length(cells) == 4
+
+    cell = cells[2]
+    @test cell["outputs"][1]["data"]["text/plain"] == "\"BAR\""
+
+    cell = cells[4]
+    @test cell["outputs"][1]["text"] == "red"
+end
+
+withenv("QUARTONOTEBOOKRUNNER_EXEFLAGS" => """["--color=yes"]""") do
+    test_example(joinpath(@__DIR__, "../examples/env_and_exeflags.qmd")) do json
+        cells = json["cells"]
+        @test length(cells) == 4
+
+        cell = cells[2]
+        @test cell["outputs"][1]["data"]["text/plain"] == "\"BAR\""
+
+        cell = cells[4]
+        @test cell["outputs"][1]["text"] == "\e[31mred\e[39m"
+    end
+end


### PR DESCRIPTION
Also add ENV vars `QUARTONOTEBOOKRUNNER_EXEFLAGS` and `QUARTONOTEBOOKRUNNER_ENV` for providing defaults for these values when not set. These are considered internals and are subject to change at any time.

Fixes #41 (that enough for what you needed there @jkrumbiegel?)