### PR TITLE
Return julia error so that quarto can display why execution failed

### DIFF
--- a/src/socket.jl
+++ b/src/socket.jl
@@ -153,11 +153,11 @@ end
 
 function _log_error(message, error, backtrace)
     @error message error backtrace
-    return (; error = message)
+    return (; error = message, juliaError = sprint(Base.showerror, error, backtrace))
 end
 function _log_error(message)
     @error message
-    return (; error = message)
+    return (; error = message, juliaError = sprint(Base.showerror, error, backtrace))
 end
 
 # TODO: check what the message schema is for this.


### PR DESCRIPTION
Just had to debug a situation where a file couldn't be executed using quarto, had to resort to running `QuartoNotebookRunner` manually because the only response I got was `running file failed`.

Sending the full julia error back should make this easier in the future.