### PR TITLE
`get` exeflags and env keys with fallback

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -306,7 +306,6 @@ function raw_markdown_chunks(path::String)
 end
 
 _recursive_merge(x::AbstractDict...) = merge(_recursive_merge, x...)
-_recursive_merge(x::AbstractVector...) = cat(x...; dims = 1)
 _recursive_merge(x...) = x[end]
 
 """

--- a/src/server.jl
+++ b/src/server.jl
@@ -35,8 +35,8 @@ mutable struct File
 end
 
 function _exeflags_and_env(options)
-    exeflags = get(options["format"]["metadata"]["julia"], "exeflags", String[])
-    env = get(options["format"]["metadata"]["julia"], "env", String[])
+    exeflags = map(String, options["format"]["metadata"]["julia"]["exeflags"])
+    env = map(String, options["format"]["metadata"]["julia"]["env"])
     return exeflags, env
 end
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -152,7 +152,9 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
         pandoc_to = get(pandoc, "to", pandoc_to_default)
 
         metadata = get(D, format, "metadata")
-        julia = get(metadata, "julia", julia_default)
+        julia = get(metadata, "julia", Dict())
+        julia_merged = _recursive_merge(julia_default, julia)
+
 
         return _options_template(;
             fig_width,
@@ -161,7 +163,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             fig_dpi,
             error,
             pandoc_to,
-            julia,
+            julia = julia_merged,
         )
     end
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -35,8 +35,8 @@ mutable struct File
 end
 
 function _exeflags_and_env(options)
-    exeflags = options["format"]["metadata"]["julia"]["exeflags"]
-    env = String.(options["format"]["metadata"]["julia"]["env"])
+    exeflags = get(options["format"]["metadata"]["julia"], "exeflags", String[])
+    env = get(options["format"]["metadata"]["julia"], "env", String[])
     return exeflags, env
 end
 

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -152,7 +152,7 @@ function _handle_response(
 end
 
 function _log_error(message, error, backtrace)
-    @error message exception=(error, backtrace)
+    @error message exception = (error, backtrace)
     return (; error = message)
 end
 function _log_error(message)

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -152,7 +152,7 @@ function _handle_response(
 end
 
 function _log_error(message, error, backtrace)
-    @error message error backtrace
+    @error message exception=(error, backtrace)
     return (; error = message)
 end
 function _log_error(message)


### PR DESCRIPTION
Got a key error on `env` when running a qmd with only exeflags set from quarto.