### PR TITLE
Precompile server machinery

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,11 +27,14 @@ PrecompileTools.@setup_workload begin
             sock
         end
 
-        println(sock, """{"type":"isready","content":{}}""")
+        JSON3.write(sock, Dict(:type => "isready", :content => Dict()))
+        println(sock)
         @assert readline(sock) == "true"
-        println(sock, """{"type":"isopen","content":"$(@__FILE__)"}""")
+        JSON3.write(sock, Dict(:type => "isopen", :content => @__FILE__)) # just to have any absolute file path that exists
+        println(sock)
         @assert readline(sock) == "false"
-        println(sock, """{"type":"stop","content":{}}""")
+        JSON3.write(sock, Dict(:type => "stop", :content => Dict()))
+        println(sock)
         wait(server)
     end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,5 +6,32 @@ PrecompileTools.@setup_workload begin
         raw_text_chunks(notebook)
         raw_text_chunks(script)
         process_results(results)
+
+        # find port to connect on
+        port, _server = Sockets.listenany(8000)
+        close(_server)
+        server = QuartoNotebookRunner.serve(; port)
+
+        sock = let
+            connected = false
+            for i = 1:20
+                try
+                    sock = Sockets.connect(port)
+                    connected = true
+                    break
+                catch
+                    sleep(0.1)
+                end
+            end
+            connected || error("Connection could not be established.")
+            sock
+        end
+
+        println(sock, """{"type":"isready","content":{}}""")
+        @assert readline(sock) == "true"
+        println(sock, """{"type":"isopen","content":"$(@__FILE__)"}""")
+        @assert readline(sock) == "false"
+        println(sock, """{"type":"stop","content":{}}""")
+        wait(server)
     end
 end


### PR DESCRIPTION
To improve responsiveness of first render using quarto, include a basic server socket connection pass in the precompilation run. Ideally, this would include `run` but it seems that wasn't desired due to #8 