### PR TITLE
Encapsulate server connection logic

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -7,32 +7,17 @@ PrecompileTools.@setup_workload begin
         raw_text_chunks(script)
         process_results(results)
 
-        # find port to connect on
-        port, _server = Sockets.listenany(8000)
-        close(_server)
-        server = QuartoNotebookRunner.serve(; port)
-
-        sock = let
-            connected = false
-            for i = 1:20
-                try
-                    sock = Sockets.connect(port)
-                    connected = true
-                    break
-                catch
-                    sleep(0.1)
-                end
-            end
-            connected || error("Connection could not be established.")
-            sock
-        end
+        server = QuartoNotebookRunner.serve()
+        sock = Sockets.connect(server.port)
 
         JSON3.write(sock, Dict(:type => "isready", :content => Dict()))
         println(sock)
         @assert readline(sock) == "true"
-        JSON3.write(sock, Dict(:type => "isopen", :content => @__FILE__)) # just to have any absolute file path that exists
+
+        JSON3.write(sock, Dict(:type => "isopen", :content => @__FILE__)) # just to have any absolute file path that exists but is not open
         println(sock)
         @assert readline(sock) == "false"
+
         JSON3.write(sock, Dict(:type => "stop", :content => Dict()))
         println(sock)
         wait(server)


### PR DESCRIPTION
Currently, the code calling `serve` from quarto is unnecessarily complex. It has to choose an open port by opening a server itself on random ports until it finds an open one, then close it and open the QuartoNotebookRunner server on that port. It's easier to just let `serve` call `listenany` itself when no port is specified. The port can then be returned via a wrapper server object.

I also moved the `listen` part out of the `@spawn` because before, I'd have to do a test connection to see if inside the task, the listening might have worked or not. By moving it in front, the `serve` function will block until the listening server is established, so the quarto code should be free to connect to it once it returns.

I also need a way to return the HMAC signing key later to implement the security mechanism, so the server object is a good vehicle for that as well. For convenience, I've added a `wait(server)` method.