### PR TITLE
Improve thread-safety

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -892,7 +892,7 @@ function close!(server::Server, path::String)
     borrow_file!(server, path) do file
         Malt.stop(file.worker)
         lock(server.lock) do
-            delete!(server.workers, path)
+            pop!(server.workers, file.path)
         end
         GC.gc()
     end

--- a/src/server.jl
+++ b/src/server.jl
@@ -817,11 +817,6 @@ function borrow_file!(
     optionally_create = false,
     options = Dict{String,Any}(),
 )
-    # first prohibit mutation of the workers lock dict
-    # but we don't want to lock the server until `f` is done executing
-    # so multiple tasks can retrieve `workerlock` at the same time
-    # but only one can unlock it at a time
-
     apath = abspath(path)
 
     prelocked, file = lock(server.lock) do

--- a/src/server.jl
+++ b/src/server.jl
@@ -5,7 +5,6 @@ mutable struct File
     path::String
     exeflags::Vector{String}
     env::Vector{String}
-    lock::ReentrantLock # should be locked for mutation and Malt evaling
 
     function File(path::String, options::Union{String,Dict{String,Any}})
         if isfile(path)
@@ -19,7 +18,7 @@ mutable struct File
                 exeflags, env = _exeflags_and_env(merged_options)
 
                 worker = cd(() -> Malt.Worker(; exeflags, env), dirname(path))
-                file = new(worker, path, exeflags, env, ReentrantLock())
+                file = new(worker, path, exeflags, env)
                 init!(file)
                 return file
             else
@@ -44,33 +43,30 @@ end
 struct Server
     workers::Dict{String,File}
     lock::ReentrantLock # should be locked for mutation/lookup of the workers dict, not for evaling on the workers. use worker lock for that
+    workerlocks::Dict{String,ReentrantLock}
     function Server()
         workers = Dict{String,File}()
-        return new(workers, ReentrantLock())
+        return new(workers, ReentrantLock(), Dict{String,ReentrantLock}())
     end
 end
 
 # Implementation.
 
 function init!(file::File)
-    lock(file.lock) do
-        worker = file.worker
-        Malt.remote_eval_fetch(worker, worker_init(file))
-    end
+    worker = file.worker
+    Malt.remote_eval_fetch(worker, worker_init(file))
 end
 
 function refresh!(file::File, options::Dict)
     exeflags, env = _exeflags_and_env(options)
-    lock(file.lock) do
-        if exeflags != file.exeflags || env != file.env
-            Malt.stop(file.worker)
-            file.worker = cd(() -> Malt.Worker(; exeflags, env), dirname(file.path))
-            file.exeflags = exeflags
-            init!(file)
-        end
-        expr = :(refresh!($(options)))
-        Malt.remote_eval_fetch(file.worker, expr)
+    if exeflags != file.exeflags || env != file.env || !Malt.isrunning(file.worker) # the worker might have been killed on another task
+        Malt.stop(file.worker)
+        file.worker = cd(() -> Malt.Worker(; exeflags, env), dirname(file.path))
+        file.exeflags = exeflags
+        init!(file)
     end
+    expr = :(refresh!($(options)))
+    Malt.remote_eval_fetch(file.worker, expr)
 end
 
 """
@@ -497,170 +493,168 @@ Evaluate the raw cells in `chunks` and return a vector of cells with the results
 in all available mimetypes.
 """
 function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogress = true)
-    lock(f.lock) do
-        refresh!(f, options)
-        cells = []
+    refresh!(f, options)
+    cells = []
 
-        has_error = false
-        allow_error_global = options["format"]["execute"]["error"]
+    has_error = false
+    allow_error_global = options["format"]["execute"]["error"]
 
-        header = "Running $(relpath(f.path, pwd()))"
-        @maybe_progress showprogress "$header" for (nth, chunk) in enumerate(chunks)
-            if chunk.type === :code
+    header = "Running $(relpath(f.path, pwd()))"
+    @maybe_progress showprogress "$header" for (nth, chunk) in enumerate(chunks)
+        if chunk.type === :code
 
-                outputs = []
+            outputs = []
 
-                if chunk.evaluate
-                    # Offset the line number by 1 to account for the triple backticks
-                    # that are part of the markdown syntax for code blocks.
-                    expr = :(render(
-                        $chunk.source,
-                        $(chunk.file),
-                        $(chunk.line + 1),
-                        $(chunk.cell_options),
-                    ))
-                    remote = Malt.remote_eval_fetch(f.worker, expr)
-                    processed = process_results(remote.results)
+            if chunk.evaluate
+                # Offset the line number by 1 to account for the triple backticks
+                # that are part of the markdown syntax for code blocks.
+                expr = :(render(
+                    $chunk.source,
+                    $(chunk.file),
+                    $(chunk.line + 1),
+                    $(chunk.cell_options),
+                ))
+                remote = Malt.remote_eval_fetch(f.worker, expr)
+                processed = process_results(remote.results)
 
-                    # Should this notebook cell be allowed to throw an error? When
-                    # not allowed, we log all errors don't generate an output.
-                    allow_error_cell = get(chunk.cell_options, "error", allow_error_global)
+                # Should this notebook cell be allowed to throw an error? When
+                # not allowed, we log all errors don't generate an output.
+                allow_error_cell = get(chunk.cell_options, "error", allow_error_global)
 
-                    if isnothing(remote.error)
-                        for display_result in remote.display_results
-                            processed_display = process_results(display_result)
-                            if !isempty(processed_display.data)
-                                push!(
-                                    outputs,
-                                    (;
-                                        output_type = "display_data",
-                                        processed_display.data,
-                                        processed_display.metadata,
-                                    ),
-                                )
-                            end
-                            if !isempty(processed_display.errors)
-                                append!(outputs, processed_display.errors)
-                                if !allow_error_cell
-                                    for each_error in processed_display.errors
-                                        file = "$(chunk.file):$(chunk.line)"
-                                        traceback = Text(join(each_error.traceback, "\n"))
-                                        @error "stopping notebook evaluation due to unexpected `show` error." file traceback
-                                        has_error = true
-                                    end
-                                end
-                            end
-                        end
-                        if !isempty(processed.data)
+                if isnothing(remote.error)
+                    for display_result in remote.display_results
+                        processed_display = process_results(display_result)
+                        if !isempty(processed_display.data)
                             push!(
                                 outputs,
                                 (;
-                                    output_type = "execute_result",
-                                    execution_count = 1,
-                                    processed.data,
-                                    processed.metadata,
+                                    output_type = "display_data",
+                                    processed_display.data,
+                                    processed_display.metadata,
                                 ),
                             )
                         end
-                    else
-                        # These are errors arising from evaluation of the contents
-                        # of a code cell, not from the `show` output of the values,
-                        # which is handled separately below.
+                        if !isempty(processed_display.errors)
+                            append!(outputs, processed_display.errors)
+                            if !allow_error_cell
+                                for each_error in processed_display.errors
+                                    file = "$(chunk.file):$(chunk.line)"
+                                    traceback = Text(join(each_error.traceback, "\n"))
+                                    @error "stopping notebook evaluation due to unexpected `show` error." file traceback
+                                    has_error = true
+                                end
+                            end
+                        end
+                    end
+                    if !isempty(processed.data)
                         push!(
                             outputs,
                             (;
-                                output_type = "error",
-                                ename = remote.error,
-                                evalue = get(processed.data, "text/plain", ""),
-                                traceback = remote.backtrace,
+                                output_type = "execute_result",
+                                execution_count = 1,
+                                processed.data,
+                                processed.metadata,
                             ),
                         )
-                        if !allow_error_cell
+                    end
+                else
+                    # These are errors arising from evaluation of the contents
+                    # of a code cell, not from the `show` output of the values,
+                    # which is handled separately below.
+                    push!(
+                        outputs,
+                        (;
+                            output_type = "error",
+                            ename = remote.error,
+                            evalue = get(processed.data, "text/plain", ""),
+                            traceback = remote.backtrace,
+                        ),
+                    )
+                    if !allow_error_cell
+                        file = "$(chunk.file):$(chunk.line)"
+                        traceback = Text(join(remote.backtrace, "\n"))
+                        @error "stopping notebook evaluation due to unexpected cell error." file traceback
+                        has_error = true
+                    end
+                end
+
+                if !isempty(remote.output)
+                    pushfirst!(
+                        outputs,
+                        (; output_type = "stream", name = "stdout", text = remote.output),
+                    )
+                end
+
+                # These are errors arising from the `show` output of the values
+                # generated by cells, not from the cell evaluation itself. So if
+                # something throws an error here then the user's `show` method
+                # has a bug.
+                if !isempty(processed.errors)
+                    append!(outputs, processed.errors)
+                    if !allow_error_cell
+                        for each_error in processed.errors
                             file = "$(chunk.file):$(chunk.line)"
-                            traceback = Text(join(remote.backtrace, "\n"))
-                            @error "stopping notebook evaluation due to unexpected cell error." file traceback
+                            traceback = Text(join(each_error.traceback, "\n"))
+                            @error "stopping notebook evaluation due to unexpected `show` error." file traceback
                             has_error = true
                         end
                     end
-
-                    if !isempty(remote.output)
-                        pushfirst!(
-                            outputs,
-                            (; output_type = "stream", name = "stdout", text = remote.output),
-                        )
-                    end
-
-                    # These are errors arising from the `show` output of the values
-                    # generated by cells, not from the cell evaluation itself. So if
-                    # something throws an error here then the user's `show` method
-                    # has a bug.
-                    if !isempty(processed.errors)
-                        append!(outputs, processed.errors)
-                        if !allow_error_cell
-                            for each_error in processed.errors
-                                file = "$(chunk.file):$(chunk.line)"
-                                traceback = Text(join(each_error.traceback, "\n"))
-                                @error "stopping notebook evaluation due to unexpected `show` error." file traceback
-                                has_error = true
-                            end
-                        end
-                    end
                 end
-
-                push!(
-                    cells,
-                    (;
-                        id = string(nth),
-                        cell_type = chunk.type,
-                        metadata = (;),
-                        source = process_cell_source(chunk.source),
-                        outputs,
-                        execution_count = chunk.evaluate ? 1 : 0,
-                    ),
-                )
-            elseif chunk.type === :markdown
-                marker = "{julia} "
-                source = chunk.source
-                if contains(chunk.source, "`$marker")
-                    parser = Parser()
-                    for (node, enter) in parser(chunk.source)
-                        if enter && node.t isa CommonMark.Code
-                            if startswith(node.literal, marker)
-                                source_code = replace(node.literal, marker => "")
-                                expr = :(render($(source_code), $(chunk.file), $(chunk.line)))
-                                remote = Malt.remote_eval_fetch(f.worker, expr)
-                                if !isnothing(remote.error)
-                                    error("Error rendering inline code: $(remote.error)")
-                                end
-                                processed = process_inline_results(remote.results)
-                                source = replace(
-                                    source,
-                                    "`$(node.literal)`" => "$processed";
-                                    count = 1,
-                                )
-                            end
-                        end
-                    end
-                end
-                push!(
-                    cells,
-                    (;
-                        id = string(nth),
-                        cell_type = chunk.type,
-                        metadata = (;),
-                        source = process_cell_source(source),
-                    ),
-                )
-            else
-                throw(ArgumentError("unknown chunk type: $(chunk.type)"))
             end
-        end
-        if has_error
-            error("Unexpected cell errors, see logs above.")
-        end
 
-        return cells
+            push!(
+                cells,
+                (;
+                    id = string(nth),
+                    cell_type = chunk.type,
+                    metadata = (;),
+                    source = process_cell_source(chunk.source),
+                    outputs,
+                    execution_count = chunk.evaluate ? 1 : 0,
+                ),
+            )
+        elseif chunk.type === :markdown
+            marker = "{julia} "
+            source = chunk.source
+            if contains(chunk.source, "`$marker")
+                parser = Parser()
+                for (node, enter) in parser(chunk.source)
+                    if enter && node.t isa CommonMark.Code
+                        if startswith(node.literal, marker)
+                            source_code = replace(node.literal, marker => "")
+                            expr = :(render($(source_code), $(chunk.file), $(chunk.line)))
+                            remote = Malt.remote_eval_fetch(f.worker, expr)
+                            if !isnothing(remote.error)
+                                error("Error rendering inline code: $(remote.error)")
+                            end
+                            processed = process_inline_results(remote.results)
+                            source = replace(
+                                source,
+                                "`$(node.literal)`" => "$processed";
+                                count = 1,
+                            )
+                        end
+                    end
+                end
+            end
+            push!(
+                cells,
+                (;
+                    id = string(nth),
+                    cell_type = chunk.type,
+                    metadata = (;),
+                    source = process_cell_source(source),
+                ),
+            )
+        else
+            throw(ArgumentError("unknown chunk type: $(chunk.type)"))
+        end
     end
+    if has_error
+        error("Unexpected cell errors, see logs above.")
+    end
+
+    return cells
 end
 
 # All but the last line of a cell should contain a newline character to end it.
@@ -791,28 +785,98 @@ is_julia_toplevel(node) =
     node.t.info == "{julia}" &&
     node.parent.t isa CommonMark.Document
 
-function loadfile!(server::Server, path::String, options::Union{String,Dict{String,Any}})
-    file = File(path, options)
-    lock(server.lock) do
-        server.workers[path] = file
-    end
-    return file
+function checkpath(path)
+    isabspath(path) || error("Path must be absolute: $path")
+    isfile(path) || error("No file at $path")
+    return
 end
 
 function run!(
     server::Server,
-    file::AbstractString;
+    path::AbstractString;
     output::Union{AbstractString,IO,Nothing} = nothing,
     showprogress::Bool = true,
     options::Union{String,Dict{String,Any}} = Dict{String,Any}(),
 )
-    f = lock(server.lock) do
-        get!(server.workers, file) do
-            @debug "file not loaded, loading first." file
-            loadfile!(server, file, options)
+    borrow_file!(server, path; optionally_create = true) do file
+        return evaluate!(file, output; showprogress, options)
+    end
+end
+
+struct NoFileEntryError <: Exception
+    path::String
+end
+
+"""
+    borrow_file!(f, server, path; optionally_create = false, options = Dict{String,Any}())
+
+Executes `f(file)` while the worker lock corresponding to the `file`
+at `path` is attained. All actions on a `File` should be wrapped in this
+so that no two tasks can mutate the `File` at the same time.
+"""
+function borrow_file!(f, server, path; optionally_create = false, options = Dict{String,Any}())
+    # first prohibit mutation of the workers lock dict
+    # but we don't want to lock the server until `f` is done executing
+    # so multiple tasks can retrieve `workerlock` at the same time
+    # but only one can unlock it at a time
+
+    checkpath(path)
+    
+    prelocked, workerlock = lock(server.lock) do
+        if haskey(server.workerlocks, path)
+            return false, server.workerlocks[path]
+        else
+            if optionally_create
+                lck = server.workerlocks[path] = ReentrantLock()
+                lock(lck) # don't let anything get to the fresh file before us
+                return true, lck
+            else
+                throw(NoFileEntryError(path))
+            end
         end
     end
-    return evaluate!(f, output; showprogress, options)
+
+    if prelocked
+        # we know nothing can have happened to the file because we just created its
+        # entry, so we can initialize the file, and delete the entry in case that fails
+        file = try 
+            _file = File(path, options)
+            lock(server.lock) do
+                haskey(server.workers, path) && error("File existed even though it shouldn't for path $path")
+                server.workers[path] = _file
+            end
+        catch err
+            lock(server.lock) do
+                # clean up
+                delete!(server.workerlocks, path)
+            end
+            rethrow(err)
+        end
+        return try
+            f(file)
+        finally
+            unlock(workerlock)
+        end
+    else
+        # we will now try to attain a previously existing lock. once we have attained
+        # it though, it could be that it is a stale lock from a file that has been
+        # removed in the meantime, or removed and reopened with a new lock. So if
+        # no lock exists or it doesn't match what we have, we recurse into `borrow_file!`.
+        # This could in principle go on forever but is very unlikely to with a small number of
+        # concurrent users.
+        lock(workerlock) do
+            current_lock, file = lock(server.lock) do
+                get(server.workerlocks, path, nothing), get(server.workers, path, nothing)
+            end
+            if current_lock !== workerlock
+                return borrow_file!(f, server, path; optionally_create)
+            else
+                file === nothing && error("No `File` existed for path $path even though there was an active lock for it. This must be a bug if all accesses to files have been wrapped in `borrow_file!`.")
+                result = f(file)
+                return result
+            end
+        end
+    end
 end
 
 """
@@ -843,15 +907,14 @@ function close!(server::Server)
 end
 
 function close!(server::Server, path::String)
-    file = lock(server.lock) do
-        file = server.workers[path]
-        delete!(server.workers, path)
-        return file
-    end
-    lock(file.lock) do
+    borrow_file!(server, path) do file
         Malt.stop(file.worker)
+        lock(server.lock) do
+            delete!(server.workerlocks, path)
+            delete!(server.workers, path)
+        end
+        GC.gc()
     end
-    GC.gc()
 end
 
 json_reader(str) = JSON3.read(str, Any)

--- a/src/server.jl
+++ b/src/server.jl
@@ -804,9 +804,11 @@ end
 """
     borrow_file!(f, server, path; optionally_create = false, options = Dict{String,Any}())
 
-Executes `f(file)` while the worker lock corresponding to the `file`
-at `path` is attained. All actions on a `File` should be wrapped in this
+Executes `f(file)` while the `file`'s `ReentrantLock` is locked.
+All actions on a `Server`'s `File` should be wrapped in this
 so that no two tasks can mutate the `File` at the same time.
+When `optionally_create` is `true`, the `File` will be created on the server
+if it doesn't exist, in which case it is passed `options`.
 """
 function borrow_file!(
     f,

--- a/test/testsets/concurrency.jl
+++ b/test/testsets/concurrency.jl
@@ -18,4 +18,7 @@
             end
         end
     end
+
+    @test isempty(s.workerlocks)
+    @test isempty(s.workers)
 end

--- a/test/testsets/concurrency.jl
+++ b/test/testsets/concurrency.jl
@@ -19,6 +19,5 @@
         end
     end
 
-    @test isempty(s.workerlocks)
     @test isempty(s.workers)
 end

--- a/test/testsets/concurrency.jl
+++ b/test/testsets/concurrency.jl
@@ -3,7 +3,7 @@
     file = joinpath(@__DIR__, "..", "examples", "soft_scope.qmd")
 
     @test_nowarn @sync begin
-        for i in 1:20
+        for i = 1:20
             Threads.@spawn begin
                 run!(s, file)
                 try

--- a/test/testsets/concurrency.jl
+++ b/test/testsets/concurrency.jl
@@ -1,0 +1,21 @@
+@testset "concurrent run and close" begin
+    s = Server()
+    file = joinpath(@__DIR__, "..", "examples", "soft_scope.qmd")
+
+    @test_nowarn @sync begin
+        for i in 1:20
+            Threads.@spawn begin
+                run!(s, file)
+                try
+                    # files may be closed already by another task, that's ok
+                    close!(s, file)
+                catch e
+                    if !(e isa QuartoNotebookRunner.NoFileEntryError)
+                        # unexpected
+                        rethrow(e)
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
- add locks to server and files
- create `borrow_file!` mechanism for simplifying concurrency
- format
- add concurrency test

After adding locks almost to everything, I've simplified the approach so that now, you "borrow" a file (which may optionally create it if you specify that) and while it's borrowed, it is inaccessible to any other task. All the functions mutating `File`s are then expected to be run under this borrowing approach, as making them all threadsafe would be much more difficult.

After this PR, I can use the mechanism to add asynchronous timeouts on top.