### PR TITLE
Add timeout feature for workers

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -153,7 +153,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
     fig_format_default = get(file_frontmatter, "fig-format", nothing)
     fig_dpi_default = get(file_frontmatter, "fig-dpi", nothing)
     error_default = get(get(D, file_frontmatter, "execute"), "error", true)
-    daemon_default = get(get(D, file_frontmatter, "execute"), "daemon", 10.0)
+    daemon_default = get(get(D, file_frontmatter, "execute"), "daemon", true)
 
     pandoc_to_default = nothing
 

--- a/test/examples/timeout.qmd
+++ b/test/examples/timeout.qmd
@@ -1,0 +1,8 @@
+---
+execute:
+    daemon: false
+---
+
+```{julia}
+1 + 1
+```

--- a/test/testsets/concurrency.jl
+++ b/test/testsets/concurrency.jl
@@ -6,15 +6,8 @@
         for i = 1:20
             Threads.@spawn begin
                 run!(s, file)
-                try
-                    # files may be closed already by another task, that's ok
-                    close!(s, file)
-                catch e
-                    if !(e isa QuartoNotebookRunner.NoFileEntryError)
-                        # unexpected
-                        rethrow(e)
-                    end
-                end
+                # files may be closed already by another task, that's ok
+                close!(s, file)
             end
         end
     end

--- a/test/testsets/worker_timeouts.jl
+++ b/test/testsets/worker_timeouts.jl
@@ -1,0 +1,27 @@
+include("../utilities/prelude.jl")
+
+@testset begin
+    s = Server()
+    base_file = joinpath(@__DIR__, "..", "examples", "timeout.qmd")
+    run!(s, base_file)
+    @test length(s.workers) == 0
+    mktempdir() do dir
+        zero_file = joinpath(dir, "zero.qmd")
+        open(zero_file, "w") do io
+            println(io, replace(read(base_file, String), "false" => "0"))
+        end
+        run!(s, zero_file)
+        @test length(s.workers) == 0
+
+        five_file = joinpath(dir, "five.qmd")
+        open(five_file, "w") do io
+            println(io, replace(read(base_file, String), "false" => "5"))
+        end
+        run!(s, five_file)
+        @test length(s.workers) == 1
+        sleep(3)
+        @test length(s.workers) == 1
+        sleep(3)
+        @test length(s.workers) == 0
+    end
+end


### PR DESCRIPTION
Workers will by default time out after 300 seconds, like in quarto. `false` will set an immediate timeout (like calling `close!` directly after `run!` and otherwise numbers give the timeout duration in seconds.

Also changes the behavior of `close!` to return whether closing the file succeeded or not, because I was starting to add too many try-catches and with async behavior it's expected that files to be closed are already closed.