### PR TITLE
Timeout server only if no workers are present

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -72,16 +72,15 @@ end
 struct Server
     workers::Dict{String,File}
     lock::ReentrantLock # should be locked for mutation/lookup of the workers dict, not for evaling on the workers. use worker locks for that
-    on_change::Base.RefValue{Union{Nothing,Function}} # an optional callback function n_workers::Int -> nothing that gets called with the server.lock locked when workers are added or removed
+    on_change::Base.RefValue{Function} # an optional callback function n_workers::Int -> nothing that gets called with the server.lock locked when workers are added or removed
     function Server()
         workers = Dict{String,File}()
-        return new(workers, ReentrantLock(), Ref{Union{Nothing,Function}}(nothing))
+        return new(workers, ReentrantLock(), Ref{Function}(identity))
     end
 end
 
 function on_change(s::Server)
-    o = s.on_change[]
-    o !== nothing && o(length(s.workers))
+    s.on_change[](length(s.workers))
     return
 end
 

--- a/test/testsets/socket_server/socket_timeout.jl
+++ b/test/testsets/socket_server/socket_timeout.jl
@@ -3,11 +3,7 @@ include("../../utilities/prelude.jl")
 using Sockets
 
 @testset "Socket timeout" begin
-    node = NodeJS_18_jll.node()
-    client = joinpath(@__DIR__, "client.js")
-    json(cmd) = JSON3.read(read(cmd, String), Any)
-
-    server = QuartoNotebookRunner.serve(; timeout = 1)
+    server = QuartoNotebookRunner.serve(; timeout = 2)
     sock = Sockets.connect(server.port)
 
     QuartoNotebookRunner._write_hmac_json(
@@ -17,25 +13,27 @@ using Sockets
     )
     @test readline(sock) == "true"
 
+    sleep_qmd = abspath(joinpath(@__DIR__, "..", "..", "examples", "sleep_3.qmd"))
+
     t1 = time()
     QuartoNotebookRunner._write_hmac_json(
         sock,
         server.key,
-        Dict(
-            :type => "run",
-            :content => abspath(joinpath(@__DIR__, "..", "..", "examples", "sleep_3.qmd")),
-        ),
+        Dict(:type => "run", :content => sleep_qmd),
     )
-
-    # check that the server stays alive during a 3 second long command, even if in the meantime
-    # shorter-lived commands are completed and the server timeout is only 1 second
-    @test json(`$node $client $(server.port) $(server.key) isready`)
-
-    # now we wait for the longer command to complete
     @test !isempty(readline(sock))
     t2 = time()
-    @test t2 - t1 > 3
+    @test t2 - t1 >= 3
 
-    # after the three seconds rendering time, the server should time out after a second
+    QuartoNotebookRunner._write_hmac_json(
+        sock,
+        server.key,
+        Dict(:type => "close", :content => sleep_qmd),
+    )
+    @test !isempty(readline(sock))
+
+    # after the three seconds rendering time, the server should time out after two seconds
     wait(server)
+    t3 = time()
+    @test t3 > 2
 end


### PR DESCRIPTION
I noticed that the timeout logic didn't quite make sense the way I previously wrote it. Before, the timer started when the last command was processed. But this meant that the server would shut down even if workers were still idling. I overlooked that users will probably not think about the control server at all (that all happens in the background) but they do want to set daemon timeouts in their quarto notebooks. If they think it's practical to keep some notebook alive for three hours, the control server should not say "nothing going on, shutting down" after five minutes.

So here I change the logic such that the timer is only started when the worker count goes to zero. As all workers time out at somepoint when used from quarto, this should give the desired behavior of workers timing out when the user is inactive, and then the server. I consider this a bug fix because I had not thought about the long-running worker timeouts correctly.