### PR TITLE
Support new structs for multicells

### DIFF
--- a/test/examples/cell_expansion.qmd
+++ b/test/examples/cell_expansion.qmd
@@ -47,3 +47,23 @@ title: Cell Expansion
     ),
 ]
 ```
+
+```{julia}
+#| multiple: true
+
+# test if newly defined structs can be returned as iterators (requires certain
+# invokelatest calls to be present)
+struct QuartoCell
+    thunk::Base.Callable
+    options::Dict
+    code::String
+end
+
+Base.iterate(c::QuartoCell) = Base.iterate(cells(c))
+Base.iterate(c::QuartoCell, state) = Base.iterate(cells(c), state)
+Base.IteratorSize(c::QuartoCell) = Base.SizeUnknown()
+
+cells(q::QuartoCell) = (q,)
+
+QuartoCell(() -> 123, Dict(), "")
+```

--- a/test/testsets/cell_expansion.jl
+++ b/test/testsets/cell_expansion.jl
@@ -1,7 +1,7 @@
 include("../utilities/prelude.jl")
 
 test_example(joinpath(@__DIR__, "../examples/cell_expansion.qmd")) do json
-    @test length(json["cells"]) == 10
+    @test length(json["cells"]) == 13
 
     cell = json["cells"][1]
     @test cell["cell_type"] == "markdown"
@@ -76,4 +76,7 @@ test_example(joinpath(@__DIR__, "../examples/cell_expansion.qmd")) do json
     source = cell["source"]
     @test any(line -> contains(line, "#| output: \"asis\""), source)
     @test any(line -> contains(line, "#| echo: false"), source)
+
+    cell = json["cells"][13]
+    @test cell["outputs"][1]["data"]["text/plain"] == "123"
 end


### PR DESCRIPTION
The multicell pipeline did not work with structs defined in the notebook, both because of `get` not being overloaded and because of world age problems.