### PR TITLE
Wrap evaluation errors in EvaluationError exception

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -530,6 +530,23 @@ macro maybe_progress(showprogress, exprs...)
     return esc(expr)
 end
 
+struct EvaluationError <: Exception
+    metadata::Vector{NamedTuple{(:kind, :file, :traceback),Tuple{Symbol,String,String}}}
+end
+
+function Base.showerror(io::IO, e::EvaluationError)
+    println(
+        io,
+        "EvaluationError: Encountered $(length(e.metadata)) error$(length(e.metadata) == 1 ? "" : "s") during evaluation",
+    )
+    for (i, meta) in enumerate(e.metadata)
+        println(io)
+        println(io, "Error ", i, " of ", length(e.metadata))
+        println(io, "@ ", meta.file)
+        println(io, meta.traceback)
+    end
+end
+
 """
     evaluate_raw_cells!(f::File, chunks::Vector)
 
@@ -540,7 +557,7 @@ function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogres
     refresh!(f, options)
     cells = []
 
-    has_error = false
+    error_metadata = NamedTuple{(:kind, :file, :traceback),Tuple{Symbol,String,String}}[]
     allow_error_global = options["format"]["execute"]["error"]
 
     header = "Running $(relpath(f.path, pwd()))"
@@ -601,9 +618,11 @@ function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogres
                                 if !allow_error_cell
                                     for each_error in processed_display.errors
                                         file = "$(chunk.file):$(chunk.line)"
-                                        traceback = Text(join(each_error.traceback, "\n"))
-                                        @error "stopping notebook evaluation due to unexpected `show` error." file traceback
-                                        has_error = true
+                                        traceback = join(each_error.traceback, "\n")
+                                        push!(
+                                            error_metadata,
+                                            (; kind = :show, file, traceback),
+                                        )
                                     end
                                 end
                             end
@@ -634,9 +653,8 @@ function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogres
                         )
                         if !allow_error_cell
                             file = "$(chunk.file):$(chunk.line)"
-                            traceback = Text(join(remote.backtrace, "\n"))
-                            @error "stopping notebook evaluation due to unexpected cell error." file traceback
-                            has_error = true
+                            traceback = join(remote.backtrace, "\n")
+                            push!(error_metadata, (; kind = :cell, file, traceback))
                         end
                     end
 
@@ -660,9 +678,8 @@ function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogres
                         if !allow_error_cell
                             for each_error in processed.errors
                                 file = "$(chunk.file):$(chunk.line)"
-                                traceback = Text(join(each_error.traceback, "\n"))
-                                @error "stopping notebook evaluation due to unexpected `show` error." file traceback
-                                has_error = true
+                                traceback = join(each_error.traceback, "\n")
+                                push!(error_metadata, (; kind = :show, file, traceback))
                             end
                         end
                     end
@@ -722,8 +739,8 @@ function evaluate_raw_cells!(f::File, chunks::Vector, options::Dict; showprogres
             throw(ArgumentError("unknown chunk type: $(chunk.type)"))
         end
     end
-    if has_error
-        error("Unexpected cell errors, see logs above.")
+    if !isempty(error_metadata)
+        throw(EvaluationError(error_metadata))
     end
 
     return cells

--- a/test/testsets/error_configuration/01.jl
+++ b/test/testsets/error_configuration/01.jl
@@ -3,31 +3,30 @@ include("../../utilities/prelude.jl")
 @testset "error_configuration/01" begin
     server = Server()
 
-    test_logger = Test.TestLogger()
-    with_logger(test_logger) do
-        qmd = joinpath(@__DIR__, "01.qmd")
-        @test_throws ErrorException run!(server, qmd)
+    qmd = joinpath(@__DIR__, "01.qmd")
+    err = try
+        run!(server, qmd)
+    catch err
+        err
     end
+    @test err isa QuartoNotebookRunner.EvaluationError
 
-    @test length(test_logger.logs) == 3
+    @test length(err.metadata) == 3
 
-    log = test_logger.logs[1]
-    @test log.level == Logging.Error
-    @test log.message == "stopping notebook evaluation due to unexpected cell error."
-    @test endswith(log.kwargs[:file], "01.qmd:9")
-    @test occursin("no method matching", string(log.kwargs[:traceback]))
+    meta = err.metadata[1]
+    @test meta.kind == :cell
+    @test endswith(meta.file, "01.qmd:9")
+    @test occursin("no method matching", meta.traceback)
 
-    log = test_logger.logs[2]
-    @test log.level == Logging.Error
-    @test log.message == "stopping notebook evaluation due to unexpected cell error."
-    @test endswith(log.kwargs[:file], "01.qmd:13")
-    @test occursin("integer division error", string(log.kwargs[:traceback]))
+    meta = err.metadata[2]
+    @test meta.kind == :cell
+    @test endswith(meta.file, "01.qmd:13")
+    @test occursin("integer division error", meta.traceback)
 
-    log = test_logger.logs[3]
-    @test log.level == Logging.Error
-    @test log.message == "stopping notebook evaluation due to unexpected `show` error."
-    @test endswith(log.kwargs[:file], "01.qmd:31")
-    @test occursin("T failed to show.", string(log.kwargs[:traceback]))
+    meta = err.metadata[3]
+    @test meta.kind == :show
+    @test endswith(meta.file, "01.qmd:31")
+    @test occursin("T failed to show.", meta.traceback)
 
     close!(server)
 end

--- a/test/testsets/error_configuration/02.jl
+++ b/test/testsets/error_configuration/02.jl
@@ -3,25 +3,25 @@ include("../../utilities/prelude.jl")
 @testset "error_configuration/02" begin
     server = Server()
 
-    test_logger = Test.TestLogger()
-    with_logger(test_logger) do
-        qmd = joinpath(@__DIR__, "02.qmd")
-        @test_throws ErrorException run!(server, qmd)
+    qmd = joinpath(@__DIR__, "02.qmd")
+    err = try
+        run!(server, qmd)
+    catch err
+        err
     end
+    @test err isa QuartoNotebookRunner.EvaluationError
 
-    @test length(test_logger.logs) == 2
+    @test length(err.metadata) == 2
 
-    log = test_logger.logs[1]
-    @test log.level == Logging.Error
-    @test log.message == "stopping notebook evaluation due to unexpected cell error."
-    @test endswith(log.kwargs[:file], "02.qmd:9")
-    @test occursin("no method matching", string(log.kwargs[:traceback]))
+    meta = err.metadata[1]
+    @test meta.kind == :cell
+    @test endswith(meta.file, "02.qmd:9")
+    @test occursin("no method matching", meta.traceback)
 
-    log = test_logger.logs[2]
-    @test log.level == Logging.Error
-    @test log.message == "stopping notebook evaluation due to unexpected cell error."
-    @test endswith(log.kwargs[:file], "02.qmd:14")
-    @test occursin("integer division error", string(log.kwargs[:traceback]))
+    meta = err.metadata[2]
+    @test meta.kind == :cell
+    @test endswith(meta.file, "02.qmd:14")
+    @test occursin("integer division error", meta.traceback)
 
     close!(server)
 end


### PR DESCRIPTION
The previous setup relied on `@error` log messages which would appear in the REPL before actually throwing a normal error. However, these "logs above" never appeared when executing code via the remote mechanism from quarto.

This PR gathers them all up in a more nicely formatted `EvaluationError` which also appears as such in the quarto console:

```
EvaluationError: Encountered 2 errors during evaluation
  
  Error 1 of 2
  @ /Users/krumbiegel/.julia/dev/QuartoNotebookRunner/test/testsets/error_configuration/02.qmd:9
  MethodError: no method matching +(::Int64, ::String)
  
  Closest candidates are:
    +(::Any, ::Any, ::Any, ::Any...)
     @ Base operators.jl:587
    +(::Real, ::Complex{Bool})
     @ Base complex.jl:319
    +(::Real, ::Complex)
     @ Base complex.jl:331
    ...
  
  Stacktrace:
   [1] top-level scope
     @ ~/.julia/dev/QuartoNotebookRunner/test/testsets/error_configuration/02.qmd:11
  
  Error 2 of 2
  @ /Users/krumbiegel/.julia/dev/QuartoNotebookRunner/test/testsets/error_configuration/02.qmd:14
  DivideError: integer division error
  Stacktrace:
   [1] div(x::Int64, y::Int64)
     @ Base ./int.jl:295
   [2] top-level scope
     @ ~/.julia/dev/QuartoNotebookRunner/test/testsets/error_configuration/02.qmd:16
```