### PR TITLE
Progress updates for `"run"` command over socket server

### DIFF
--- a/test/testsets/socket_server/socket_timeout.jl
+++ b/test/testsets/socket_server/socket_timeout.jl
@@ -21,6 +21,7 @@ using Sockets
         server.key,
         Dict(:type => "run", :content => sleep_qmd),
     )
+    @test occursin("progress_update", readline(sock))
     @test !isempty(readline(sock))
     t2 = time()
     @test t2 - t1 >= 3


### PR DESCRIPTION
There was no way for quarto to inform the user where in the rendering process the worker was, because the progress meter is only shown in the server's console.

This PR adds the option to pass a callback function into `run!` that is called before a code chunk should be evaluated. The index of that chunk in the list of all chunks that can be evaluated is then sent over the tcp connection along with the line and source of that chunk.

I've passed on my first idea to capture and send over stdout/stderr while QuartoNotebookRunner is going, because that would send errors twice and could easily get messy because the output will not be formatted for the client. And it's more complex to implement, too. This version here is nice and predictable.

On the quarto side, I have implemented the corresponding logging code that prints out info similar to this (I'm sending more info than strictly necessary so changes to the display style can be made over there). Currently, I show the first significant line (neither quarto options nor empty), cropped to the console width, so that the users can orient themselves:

```
Running [ 1/10] at line 6:  # First we import our depende…
Running [ 2/10] at line 12:  x2 = 3 + 4
Running [ 3/10] at line 18:  x3 = 5 + 6
Running [ 4/10] at line 22:  x4 = 7 + 8
Running [ 5/10] at line 26:  x5 = 9 + 10
Running [ 6/10] at line 30:  x6 = 11 + 12
Running [ 7/10] at line 34:  x7 = 13 + 14
Running [ 8/10] at line 38:  x8 = 15 + 16
Running [ 9/10] at line 42:  x9 = 17 + 18
```
