### PR TITLE
try-catch pwd in case it's deleted after starting the server

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -571,7 +571,8 @@ function evaluate_raw_cells!(
     error_metadata = NamedTuple{(:kind, :file, :traceback),Tuple{Symbol,String,String}}[]
     allow_error_global = options["format"]["execute"]["error"]
 
-    header = "Running $(relpath(f.path, pwd()))"
+    wd = try pwd() catch; "" end
+    header = "Running $(relpath(f.path, wd))"
 
     chunks_to_evaluate = sum(c -> c.type === :code && c.evaluate, chunks)
     ith_chunk_to_evaluate = 1


### PR DESCRIPTION
Fixes https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/93, the other option would be to not `relpath` at all but it seems useful enough to do so.