### PR TITLE
Rename `multiple` cell option to `expand`

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -578,12 +578,12 @@ function evaluate_raw_cells!(
 
     @maybe_progress showprogress "$header" for (nth, chunk) in enumerate(chunks)
         if chunk.type === :code
-            is_multiple = get(chunk.cell_options, "multiple", false) === true
-            # When we're not evaluating the code, or when there is a `multiple`
+            expand_cell = get(chunk.cell_options, "expand", false) === true
+            # When we're not evaluating the code, or when there is an `expand`
             # cell output then we immediately splice in the cell code. The
-            # results of evaluating a `multiple` cell are added later on and are
+            # results of evaluating an `expand` cell are added later on and are
             # not considered direct outputs of this cell.
-            if !chunk.evaluate || is_multiple
+            if !chunk.evaluate || expand_cell
                 push!(
                     cells,
                     (;
@@ -704,12 +704,12 @@ function evaluate_raw_cells!(
                     push!(
                         cells,
                         (;
-                            id = is_multiple ? string(nth, "_", mth) : string(nth),
+                            id = expand_cell ? string(nth, "_", mth) : string(nth),
                             cell_type = chunk.type,
                             metadata = (;),
                             source = process_cell_source(
                                 remote.code,
-                                is_multiple ? remote.cell_options : Dict(),
+                                expand_cell ? remote.cell_options : Dict(),
                             ),
                             outputs,
                             execution_count = 1,
@@ -729,7 +729,7 @@ function evaluate_raw_cells!(
                             expr = :(render($(source_code), $(chunk.file), $(chunk.line)))
                             # There should only ever be a single result from an
                             # inline evaluation since you can't pass cell
-                            # options and so `multiple` will always be `false`.
+                            # options and so `expand` will always be `false`.
                             remote = only(Malt.remote_eval_fetch(f.worker, expr))
                             if !isnothing(remote.error)
                                 # file location is not straightforward to determine with inline literals, but just printing the (presumably short)
@@ -777,7 +777,7 @@ end
 # All but the last line of a cell should contain a newline character to end it.
 # The optional `cell_options` argument is a dictionary of cell attributes which
 # are written into the processed cell source when the cell is the result of an
-# expansion of a `multiple` cell.
+# expansion of an `expand` cell.
 function process_cell_source(source::AbstractString, cell_options::Dict = Dict())
     lines = collect(eachline(IOBuffer(source); keep = true))
     if !isempty(lines)

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -167,7 +167,7 @@ function worker_init(f::File)
 
         # Recursively render cell thunks. This might be an `include_str` call,
         # which is the starting point for a source cell, or it may be a
-        # user-provided thunk that comes from a source cell with `multiple` set
+        # user-provided thunk that comes from a source cell with `expand` set
         # to `true`.
         function _render_thunk(
             thunk::Base.Callable,
@@ -175,8 +175,8 @@ function worker_init(f::File)
             cell_options::AbstractDict = Dict{String,Any}(),
         )
             captured, display_results = with_inline_display(thunk, cell_options)
-            if get(cell_options, "multiple", false) === true
-                # A cell expansion with `multiple` might itself also contain
+            if get(cell_options, "expand", false) === true
+                # A cell expansion with `expand` might itself also contain
                 # cells that expand to multiple cells, so we need to flatten
                 # the results to a single list of cells before passing back
                 # to the server. Cell expansion is recursive.

--- a/test/examples/cell_expansion.qmd
+++ b/test/examples/cell_expansion.qmd
@@ -4,7 +4,7 @@ title: Cell Expansion
 
 ```{julia}
 #| echo: false
-#| multiple: true
+#| expand: true
 [(;
     thunk = function ()
         println("print call")
@@ -19,7 +19,7 @@ title: Cell Expansion
 ```
 
 ```{julia}
-#| multiple: true
+#| expand: true
 [
     (;
         thunk = function ()
@@ -28,17 +28,17 @@ title: Cell Expansion
                     thunk = function ()
                         return [(; thunk = () -> 1, options = Dict("layout-ncol" => 1))]
                     end,
-                    options = Dict("multiple" => true),
+                    options = Dict("expand" => true),
                 ),
                 (;
                     thunk = function ()
                         return [(; thunk = () -> (display(2); 2)), (; thunk = () -> 3)]
                     end,
-                    options = Dict("multiple" => true),
+                    options = Dict("expand" => true),
                 ),
             ]
         end,
-        options = Dict("multiple" => true),
+        options = Dict("expand" => true),
     ),
     (; thunk = () -> 4),
     (;
@@ -49,7 +49,7 @@ title: Cell Expansion
 ```
 
 ```{julia}
-#| multiple: true
+#| expand: true
 
 # test if newly defined structs can be returned as iterators (requires certain
 # invokelatest calls to be present)


### PR DESCRIPTION
It does communicate a bit better what's going on, and `multiple` implies there need to be >1 outputs, which is not true.