### PR TITLE
Close socket when receiving invalid json or hmac

### DIFF
--- a/src/socket.jl
+++ b/src/socket.jl
@@ -179,7 +179,9 @@ function serve(;
                             end
                             @error msg error
                             _write_json(socket, (; error = msg))
-                            continue
+                            # close connection with clients sending wrong hmacs or invalid json
+                            # (could be other processes mistakingly targeting our port)
+                            close(socket)
                         end
                         @debug "Received request" json
 

--- a/test/testsets/socket_server/hmac_signing.jl
+++ b/test/testsets/socket_server/hmac_signing.jl
@@ -17,6 +17,10 @@ using Sockets
     # check that an error is returned and no document has been run if the key is wrong
     QuartoNotebookRunner._write_hmac_json(sock, wrong_key, command)
     @test occursin("Incorrect HMAC digest", readline(sock))
+    @test eof(sock) # server closes upon receiving wrong hmac
+
+    # reconnect
+    sock = Sockets.connect(server.port)
     @test lock(server.notebookserver.lock) do
         isempty(server.notebookserver.workers)
     end


### PR DESCRIPTION
While we cannot be certain that this fixes the hang described in https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/91 it at least makes more sense to disallow a client that doesn't send compatible data to continue doing so.

If hangs keep appearing for other users, we can try to look into other solutions.