### PR TITLE
Add ability to render R code blocks with RCall

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -324,12 +324,20 @@ function raw_markdown_chunks(path::String)
                         "Cannot handle an `eval` code cell option with value $(repr(evaluate)), only true or false.",
                     )
                 end
-                language = is_julia_toplevel(node) ? :julia :
-                    is_r_toplevel(node) ? :r :
-                    error("Unhandled code block language")
+                language =
+                    is_julia_toplevel(node) ? :julia :
+                    is_r_toplevel(node) ? :r : error("Unhandled code block language")
                 push!(
                     raw_chunks,
-                    (type = :code, language = language, source, file = path, line, evaluate, cell_options),
+                    (
+                        type = :code,
+                        language = language,
+                        source,
+                        file = path,
+                        line,
+                        evaluate,
+                        cell_options,
+                    ),
                 )
             end
         end
@@ -722,15 +730,21 @@ function evaluate_raw_cells!(
                         push!(
                             cells,
                             (;
-                                id = string(expand_cell ? string(nth, "_", mth) : string(nth), "_code_prefix"),
+                                id = string(
+                                    expand_cell ? string(nth, "_", mth) : string(nth),
+                                    "_code_prefix",
+                                ),
                                 cell_type = :markdown,
                                 metadata = (;),
-                                source = process_cell_source("""
-                                    ```r
-                                    $(strip_cell_options(chunk.source))
-                                    ```
-                                    """, Dict())
-                            )
+                                source = process_cell_source(
+                                    """
+           ```r
+           $(strip_cell_options(chunk.source))
+           ```
+           """,
+                                    Dict(),
+                                ),
+                            ),
                         )
                         # We also need to hide the real code cell in this case, which contains possible formatting
                         # settings in its YAML front-matter and which can therefore not be omitted entirely.
@@ -743,10 +757,7 @@ function evaluate_raw_cells!(
                             id = expand_cell ? string(nth, "_", mth) : string(nth),
                             cell_type = chunk.type,
                             metadata = (;),
-                            source = process_cell_source(
-                                chunk.source,
-                                cell_options,
-                            ),
+                            source = process_cell_source(chunk.source, cell_options),
                             outputs,
                             execution_count = 1,
                         ),

--- a/src/server.jl
+++ b/src/server.jl
@@ -447,6 +447,7 @@ function raw_script_chunks(path::String)
                     raw_chunks,
                     (;
                         type = :code,
+                        language = :julia,
                         source,
                         file = path,
                         line = start_line,

--- a/src/server.jl
+++ b/src/server.jl
@@ -846,11 +846,11 @@ function process_cell_source(source::AbstractString, cell_options::Dict = Dict()
 end
 
 function strip_cell_options(source::AbstractString)
-    lines = split(source, "\n")
+    lines = collect(eachline(IOBuffer(source); keep = true))
     keep_from = something(findfirst(lines) do line
         !startswith(line, "#|")
     end, 1)
-    join(lines[keep_from:end], "\n")
+    join(lines[keep_from:end])
 end
 
 function wrap_with_r_boilerplate(code)

--- a/test/examples/integrations/R_code_blocks_with_RCall.qmd
+++ b/test/examples/integrations/R_code_blocks_with_RCall.qmd
@@ -64,3 +64,5 @@ And this is Julia accessing a variable from R
 ```{julia}
 @rget a
 ```
+
+Inline interpolation using R: `{r} a + 1`

--- a/test/examples/integrations/R_code_blocks_with_RCall.qmd
+++ b/test/examples/integrations/R_code_blocks_with_RCall.qmd
@@ -1,0 +1,66 @@
+---
+title: R code blocks with RCall
+fig-width: 4
+fig-height: 3
+fig-dpi: 150
+fig-format: png
+julia:
+    exeflags: ["--project=RCall"]
+---
+
+This is an R code block but RCall has not been made available in the session, yet, so it will fail.
+
+```{r}
+x <- 1
+```
+
+Here we make RCall available, `import RCall` would also work
+
+```{julia}
+using RCall
+
+x = 123
+```
+
+This is R code accessing a variable from Julia
+
+```{r}
+a <- 5 * $x
+```
+
+Here we have a plot in R with a more complex interpolation
+
+```{r}
+#| label: fig-rplot
+#| fig-cap: A plot done with an implicit R cell
+plot($(sin.(0:0.1:4pi)))
+```
+
+And here a data.frame in R, which is auto-converted to a Julia `DataFrame`
+
+```{r}
+#| label: tbl-dataframe
+#| tbl-cap: A data.frame, autoconverted to Julia
+numeric_data <- c(1, 2, 3, 4, 5)
+boolean_data <- c(TRUE, FALSE, TRUE, FALSE, TRUE)
+categorical_data <- c("A", "B", "C", "A", "B")
+
+# Combine the data into a data frame
+df <- data.frame(
+  Numeric = numeric_data,
+  Boolean = boolean_data,
+  Categorical = as.factor(categorical_data)
+)
+```
+
+This cell contains an R error
+
+```{r}
+x + y
+```
+
+And this is Julia accessing a variable from R
+
+```{julia}
+@rget a
+```

--- a/test/testsets/integrations/R_code_blocks_with_RCall.jl
+++ b/test/testsets/integrations/R_code_blocks_with_RCall.jl
@@ -1,0 +1,32 @@
+include("../../utilities/prelude.jl")
+
+test_example(joinpath(@__DIR__, "../../examples/integrations/R_code_blocks_with_RCall.qmd")) do json
+    cells = json["cells"]
+    
+    @test occursin("RCall must be imported", cells[3]["outputs"][1]["traceback"][1])
+
+    @test cells[8]["outputs"][1]["data"]["text/plain"] == "615.0"
+
+    # plot
+    @test !isempty(cells[11]["outputs"][1]["data"]["image/png"])
+
+    # dataframe
+    @test occursin("DataFrame", cells[14]["outputs"][1]["data"]["text/plain"])
+    @test !isempty(cells[14]["outputs"][1]["data"]["text/html"])
+
+    @test cells[17]["outputs"][1]["traceback"][1] == "REvalError: Error: object 'x' not found"
+
+    @test cells[19]["outputs"][1]["data"]["text/plain"] == "615.0"
+
+    for (i, cell) in enumerate(cells)
+        if endswith("code_prefix", cell["id"])
+            @test cell["cell_type"] == "markdown"
+            @test cell["source"][1] == "```r\n"
+            @test cell["source"][end] == "```"
+            following = cells[i+1]
+            @test following["cell_type"] == "code"
+            @test any(==("#| echo: false\n"), following["source"])
+            
+        end
+    end
+end

--- a/test/testsets/integrations/R_code_blocks_with_RCall.jl
+++ b/test/testsets/integrations/R_code_blocks_with_RCall.jl
@@ -1,8 +1,10 @@
 include("../../utilities/prelude.jl")
 
-test_example(joinpath(@__DIR__, "../../examples/integrations/R_code_blocks_with_RCall.qmd")) do json
+test_example(
+    joinpath(@__DIR__, "../../examples/integrations/R_code_blocks_with_RCall.qmd"),
+) do json
     cells = json["cells"]
-    
+
     @test occursin("RCall must be imported", cells[3]["outputs"][1]["traceback"][1])
 
     @test cells[8]["outputs"][1]["data"]["text/plain"] == "615.0"
@@ -14,7 +16,8 @@ test_example(joinpath(@__DIR__, "../../examples/integrations/R_code_blocks_with_
     @test occursin("DataFrame", cells[14]["outputs"][1]["data"]["text/plain"])
     @test !isempty(cells[14]["outputs"][1]["data"]["text/html"])
 
-    @test cells[17]["outputs"][1]["traceback"][1] == "REvalError: Error: object 'x' not found"
+    @test cells[17]["outputs"][1]["traceback"][1] ==
+          "REvalError: Error: object 'x' not found"
 
     @test cells[19]["outputs"][1]["data"]["text/plain"] == "615.0"
 
@@ -26,7 +29,7 @@ test_example(joinpath(@__DIR__, "../../examples/integrations/R_code_blocks_with_
             following = cells[i+1]
             @test following["cell_type"] == "code"
             @test any(==("#| echo: false\n"), following["source"])
-            
+
         end
     end
 end

--- a/test/testsets/integrations/R_code_blocks_with_RCall.jl
+++ b/test/testsets/integrations/R_code_blocks_with_RCall.jl
@@ -21,6 +21,10 @@ test_example(
 
     @test cells[19]["outputs"][1]["data"]["text/plain"] == "615.0"
 
+    @test any(cells[20]["source"]) do line
+        occursin("Inline interpolation using R: 616\\.0", line)
+    end
+
     for (i, cell) in enumerate(cells)
         if endswith("code_prefix", cell["id"])
             @test cell["cell_type"] == "markdown"
@@ -29,7 +33,6 @@ test_example(
             following = cells[i+1]
             @test following["cell_type"] == "code"
             @test any(==("#| echo: false\n"), following["source"])
-
         end
     end
 end


### PR DESCRIPTION
Code blocks with `{r}` undergo a simple source transformation which adds code that checks that the `RCall` symbol is available and points to the expected module. If that's the case, the whole cell (minus cell options) is treated as a string to be used inside the `RCall.R_str` macro, the return value of which is `RCall.rcopy`d to the Julia side again, to be used as the cell output.

For the code output we have to be a bit tricky to get R syntax highlighting. The actual code cell is always going to be treated as julia because the ipynb format doesn't support multiple languages. But we can insert a simple markdown cell with an R code block into which we copy the source code minus cell options. The code with cell options remains in the code cell but that one gets the `echo: false` option added so it's not visible. But this makes cell annotations relating to the output work, like figure or table captions.

Here's an example script:

````markdown
---
engine: julia
---

This is an R code block but RCall has not been made available in the session, yet, so it will fail.

```{r}
x <- 1
```

Here we make RCall available, `import RCall` would also work

```{julia}
using RCall

x = 123
```

This is R code accessing a variable from Julia

```{r}
a <- 5 * $x
```

Here we have a plot in R with a more complex interpolation

```{r}
#| label: fig-rplot
#| fig-cap: A plot done with an implicit R cell
plot($(sin.(0:0.1:4pi)))
```

And here a data.frame in R, which is auto-converted to a Julia `DataFrame`

```{r}
#| label: tbl-dataframe
#| tbl-cap: A data.frame, autoconverted to Julia
numeric_data <- c(1, 2, 3, 4, 5)
boolean_data <- c(TRUE, FALSE, TRUE, FALSE, TRUE)
categorical_data <- c("A", "B", "C", "A", "B")

# Combine the data into a data frame
df <- data.frame(
  Numeric = numeric_data,
  Boolean = boolean_data,
  Categorical = as.factor(categorical_data)
)
```

This cell contains an R error

```{r}
x + y
```

And this is Julia accessing a variable from R

```{julia}
@rget a
```
````

And here a screenshot of the rendered html:

<img width="546" alt="image" src="https://github.com/PumasAI/QuartoNotebookRunner.jl/assets/22495855/62794112-3a83-44bd-851a-3c866bb5c118">
