### PR TITLE
Implement parameters

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -840,7 +840,17 @@ function evaluate_raw_cells!(
     return cells
 end
 
-function evaluate_params!(f, params::Dict)
+function evaluate_params!(f, params::Dict{String})
+    invalid_param_keys = filter(!Base.isidentifier, keys(params))
+    if !isempty(invalid_param_keys)
+        plu = length(invalid_param_keys) > 1
+        throw(
+            ArgumentError(
+                "Found parameter key$(plu ? "s that are not " : " that is not a ") valid Julia identifier$(plu ? "s" : ""): $(join((repr(k) for k in invalid_param_keys), ", ", " and ")).",
+            ),
+        )
+    end
+
     exprs = map(collect(pairs(params))) do (key, value)
         :(@eval getfield(Main, :Notebook) $(Symbol(key::String)) = $value)
     end

--- a/test/examples/parameters.qmd
+++ b/test/examples/parameters.qmd
@@ -1,0 +1,43 @@
+---
+params:
+    a: 1
+    b: 2.0
+    c: some string
+    d: "some other string"
+    e: ["string", "array"]
+    f: [1, 2, 3]
+    g: {a: 1, b: 2}
+---
+
+```{julia}
+a
+```
+
+```{julia}
+b
+```
+
+```{julia}
+c
+```
+
+```{julia}
+d
+```
+
+```{julia}
+print(repr(e))
+```
+
+```{julia}
+print(repr(f))
+```
+
+```{julia}
+g["a"]
+```
+
+```{julia}
+g["b"]
+```
+

--- a/test/testsets/parameters.jl
+++ b/test/testsets/parameters.jl
@@ -39,3 +39,15 @@ end
     @test cells[14].outputs[1].data["text/plain"] == "4"
     @test cells[16].outputs[1].data["text/plain"] == "2"
 end
+
+@testset "Invalid parameters" begin
+    s = Server()
+    options = Dict{String,Any}("params" => Dict("invalid identifier" => 7))
+    @test_throws ArgumentError(
+        "Found parameter key that is not a  valid Julia identifier: \"invalid identifier\".",
+    ) QuartoNotebookRunner.run!(
+        s,
+        joinpath(@__DIR__, "../examples/parameters.qmd");
+        options,
+    )
+end

--- a/test/testsets/parameters.jl
+++ b/test/testsets/parameters.jl
@@ -1,0 +1,41 @@
+include("../utilities/prelude.jl")
+
+test_example(joinpath(@__DIR__, "../examples/parameters.qmd")) do json
+    cells = json["cells"]
+
+    @test cells[2]["outputs"][1]["data"]["text/plain"] == "1"
+    @test cells[4]["outputs"][1]["data"]["text/plain"] == "2.0"
+    @test cells[6]["outputs"][1]["data"]["text/plain"] == "\"some string\""
+    @test cells[8]["outputs"][1]["data"]["text/plain"] == "\"some other string\""
+    @test cells[10]["outputs"][1]["text"] == "[\"string\", \"array\"]"
+    @test cells[12]["outputs"][1]["text"] == "[1, 2, 3]"
+    @test cells[14]["outputs"][1]["data"]["text/plain"] == "1"
+    @test cells[16]["outputs"][1]["data"]["text/plain"] == "2"
+end
+
+@testset "parameters via options" begin
+    s = Server()
+    options = Dict{String,Any}(
+        "params" => Dict("a" => 7, "c" => "cli override"),
+        "format" => Dict(
+            "metadata" =>
+                Dict("params" => Dict("a" => 5, "b" => 6.0, "g" => Dict("a" => 4))),
+        ),
+    )
+    json = QuartoNotebookRunner.run!(
+        s,
+        joinpath(@__DIR__, "../examples/parameters.qmd");
+        options,
+    )
+
+    cells = json.cells
+
+    @test cells[2].outputs[1].data["text/plain"] == "7"
+    @test cells[4].outputs[1].data["text/plain"] == "6.0"
+    @test cells[6].outputs[1].data["text/plain"] == "\"cli override\""
+    @test cells[8].outputs[1].data["text/plain"] == "\"some other string\""
+    @test cells[10].outputs[1].text == "[\"string\", \"array\"]"
+    @test cells[12].outputs[1].text == "[1, 2, 3]"
+    @test cells[14].outputs[1].data["text/plain"] == "4"
+    @test cells[16].outputs[1].data["text/plain"] == "2"
+end


### PR DESCRIPTION
Fixes #36 

Dicts are merged recursively, so one could use dicts as parameters and override only some of their values via CLI. I think that matches how we do merging in other places.

Example `parameters.qmd`:

````md
---
engine: julia
title: Parameters
params:
  a: 1
  b: [1, 2, 3]
---

a is `{julia} a` and b is `{julia} b`

```{julia}
a .+ b
```
````

Then `quarto render parameters.qmd --to=html -P a:2`:

<img width="835" alt="image" src="https://github.com/PumasAI/QuartoNotebookRunner.jl/assets/22495855/7fb893ab-19e4-4ef2-95af-274b5ad18642">

