### PR TITLE
Error handling for expanded cells

### DIFF
--- a/src/worker.jl
+++ b/src/worker.jl
@@ -208,7 +208,7 @@ function worker_init(f::File)
                     ),)
                 else
 
-                    if !Base.isiterable(typeof(captured.value))
+                    if !(Base.@invokelatest Base.isiterable(typeof(captured.value)))
                         return ((;
                             code = "",
                             cell_options = Dict{String,Any}(),

--- a/test/examples/cell_expansion.qmd
+++ b/test/examples/cell_expansion.qmd
@@ -55,7 +55,7 @@ title: Cell Expansion
 # invokelatest calls to be present)
 struct QuartoCell
     thunk::Base.Callable
-    options::Dict
+    options::Dict{String,Any}
     code::String
 end
 

--- a/test/examples/cell_expansion_errors.qmd
+++ b/test/examples/cell_expansion_errors.qmd
@@ -31,3 +31,32 @@ execute:
 ]
 ```
 
+```{julia}
+#| expand: true
+
+[(; thunk = "not a function")]
+```
+
+```{julia}
+#| expand: true
+
+:not_an_iterable
+```
+
+```{julia}
+#| expand: true
+
+[(; no_thunk_here = "")]
+```
+
+```{julia}
+#| expand: true
+
+[(; thunk = () -> 123, code = :invalid_code)]
+```
+
+```{julia}
+#| expand: true
+
+[(; thunk = () -> 123, options = Dict(:invalid => "options"))]
+```

--- a/test/examples/cell_expansion_errors.qmd
+++ b/test/examples/cell_expansion_errors.qmd
@@ -1,0 +1,33 @@
+---
+engine: julia
+execute:
+    error: true
+---
+
+```{julia}
+#| expand: true
+
+"a" + "b"
+```
+
+```{julia}
+#| expand: true
+
+[
+    (; thunk = () -> "no problem here"),
+    (;
+        thunk = function ()
+            return [
+                (;
+                    thunk = function ()
+                        return [(; thunk = () -> error("a nested thunk error"))]
+                    end,
+                    options = Dict("expand" => true),
+                ),
+            ]
+        end,
+        options = Dict("expand" => true),
+    ),
+]
+```
+

--- a/test/testsets/cell_expansion.jl
+++ b/test/testsets/cell_expansion.jl
@@ -86,6 +86,34 @@ test_example(joinpath(@__DIR__, "../examples/cell_expansion_errors.qmd")) do jso
     cells = json["cells"]
 
     @test any(x -> occursin("MethodError", x), cells[3]["outputs"][]["traceback"])
+
     @test cells[6]["outputs"][]["data"]["text/plain"] == "\"no problem here\""
+
     @test any(x -> occursin("a nested thunk error", x), cells[7]["outputs"][]["traceback"])
+
+    cell = cells[10]
+    @test cell["outputs"][]["ename"] == "Invalid return value for expanded cell"
+    @test any(
+        x -> occursin("not a function of type `Base.Callable`", x),
+        cell["outputs"][]["traceback"],
+    )
+
+    cell = cells[13]
+    @test cell["outputs"][]["ename"] == "Invalid return value for expanded cell"
+    @test any(x -> occursin("is not iterable", x), cell["outputs"][]["traceback"])
+
+    cell = cells[16]
+    @test cell["outputs"][]["ename"] == "Invalid return value for expanded cell"
+    @test any(
+        x -> occursin("must have a property `thunk`", x),
+        cell["outputs"][]["traceback"],
+    )
+
+    cell = cells[19]
+    @test cell["outputs"][]["ename"] == "Invalid return value for expanded cell"
+    @test any(x -> occursin("`code` property", x), cell["outputs"][]["traceback"])
+
+    cell = cells[22]
+    @test cell["outputs"][]["ename"] == "Invalid return value for expanded cell"
+    @test any(x -> occursin("`options` property", x), cell["outputs"][]["traceback"])
 end

--- a/test/testsets/cell_expansion.jl
+++ b/test/testsets/cell_expansion.jl
@@ -81,3 +81,11 @@ test_example(joinpath(@__DIR__, "../examples/cell_expansion.qmd")) do json
     cell = json["cells"][13]
     @test cell["outputs"][1]["data"]["text/plain"] == "123"
 end
+
+test_example(joinpath(@__DIR__, "../examples/cell_expansion_errors.qmd")) do json
+    cells = json["cells"]
+
+    @test any(x -> occursin("MethodError", x), cells[3]["outputs"][]["traceback"])
+    @test cells[6]["outputs"][]["data"]["text/plain"] == "\"no problem here\""
+    @test any(x -> occursin("a nested thunk error", x), cells[7]["outputs"][]["traceback"])
+end


### PR DESCRIPTION
Before, when any of the conditions for using the output of an expanded cell didn't hold, you'd crash the worker with some obscure error like `cannot iterate MethodError` or so. Now, these cases are all caught separately and given explanatory error messages.