### PR TITLE
Add `test_pr` for testing PRs

### DIFF
--- a/src/QuartoNotebookRunner.jl
+++ b/src/QuartoNotebookRunner.jl
@@ -45,6 +45,7 @@ include("WorkerSetup.jl")
 include("server.jl")
 include("socket.jl")
 include("worker.jl")
+include("utilities.jl")
 include("precompile.jl")
 
 end # module QuartoNotebookRunner

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,44 @@
+"""
+    test_pr(cmd::Cmd; url::String, rev::String)
+
+Test a PR by running the given command with the PR's changes. `url` defaults to
+the `QuartoNotebookRunner.jl` repo. `rev` is required, and should be the branch
+name of the PR. `cmd` should be the `quarto render` command to run.
+"""
+function test_pr(
+    cmd::Cmd;
+    url::String = "https://github.com/PumasAI/QuartoNotebookRunner.jl",
+    rev::String,
+)
+    # Require the user to already have a `quarto` install on their path.
+    quarto = Sys.which("quarto")
+    if isnothing(quarto)
+        error("Quarto not found. Please install Quarto.")
+    end
+
+    # We require at least v1.5.29 to run this backend.
+    version = VersionNumber(readchomp(`quarto --version`))
+    if version < v"1.5.29"
+        error(
+            "Quarto version $version is not supported. Please upgrade to at least v1.5.29.",
+        )
+    end
+
+    mktempdir() do dir
+        file = joinpath(dir, "file.jl")
+        write(
+            file,
+            """
+            import Pkg
+            Pkg.add(; url = $(repr(url)), rev = $(repr(rev)))
+            """,
+        )
+        run(`$(Base.julia_cmd()) --startup-file=no --project=$dir $file`)
+        run(
+            addenv(
+                `$cmd --no-execute-daemon --execute-debug`,
+                "QUARTO_JULIA_PROJECT" => dir,
+            ),
+        )
+    end
+end


### PR DESCRIPTION
From https://github.com/PumasAI/QuartoNotebookRunner.jl/pull/136 it's clearly difficult to correctly setup `quarto` to correctly run the backend using a particular PR's branch so that we can more easily have people verify that a fix is correct. This helper aims to make that much simpler.

@jkrumbiegel I'm not 100% sure that `--no-execute-daemon` is having the intended effect on reruns, see the below outputs. In particular the differences between the `Transport file` logs, the first of which I'd expect, but the second one is saying it is reusing the server, even though `--no-execute-daemon` flag is passed. Any idea what's happening there?

```
julia> QuartoNotebookRunner.test_pr(`quarto render test/examples/integrations/Plots.qmd`; rev = "mh/plots-pdf")
    Updating git-repo `https://github.com/PumasAI/QuartoNotebookRunner.jl`
   Resolving package versions...
    Updating `/private/var/folders/09/t9pc5r114yg9pfrf28lb2d440000gn/T/jl_yDNrHE/Project.toml`
  [4c0109c6] + QuartoNotebookRunner v0.10.2 `https://github.com/PumasAI/QuartoNotebookRunner.jl#mh/plots-pdf`
...
- Transport file /Users/mike/Library/Caches/quarto/julia/julia_transport.txt doesn't exist
Starting julia control server process. This might take a while...
- Custom julia project set via QUARTO_JULIA_PROJECT="/var/folders/09/t9pc5r114yg9pfrf28lb2d440000gn/T/jl_yDNrHE". Checking if QuartoNotebookRunner can be loaded.
- QuartoNotebookRunner could be loaded successfully.
- Starting detached julia server through julia, once transport file exists, server should be running.
- Transport file did not exist, yet.
- Transport file did not exist, yet.
- Transport file did not exist, yet.
- Transport file did not exist, yet.
- Transport file did not exist, yet.
- Transport file read successfully.
Julia server process started.
- Connecting to server at port 8002, pid 59472
- write command "isready" to socket server
- received server response
- Transport file read successfully.
- write command "isopen" to socket server
- received server response
- write command "run" to socket server
- received server response
- received progress update response, listening for further responses
Running [1/3] at line 9:  Pkg.activate("Plots")
- received server response
- received progress update response, listening for further responses
Running [2/3] at line 14:  import Plots
- received server response
- received progress update response, listening for further responses
Running [3/3] at line 18:  Plots.plot(Plots.fakedata(50, 5), w = 3)
- received server response
- write command "close" to socket server
- received server response
pandoc 
  to: html
  output-file: Plots.html
  standalone: true
  section-divs: true
  html-math-method: mathjax
  wrap: none
  default-image-extension: png
  
metadata
  document-css: false
  link-citations: true
  date-format: long
  lang: en
  title: Plots integration
  
Output created: Plots.html

julia> QuartoNotebookRunner.test_pr(`quarto render test/examples/integrations/Plots.qmd`; rev = "mh/plots-pdf")
    Updating git-repo `https://github.com/PumasAI/QuartoNotebookRunner.jl`
   Resolving package versions...
    Updating `/private/var/folders/09/t9pc5r114yg9pfrf28lb2d440000gn/T/jl_sJqWJp/Project.toml`
  [4c0109c6] + QuartoNotebookRunner v0.10.2 `https://github.com/PumasAI/QuartoNotebookRunner.jl#mh/plots-pdf`
...
- Transport file /Users/mike/Library/Caches/quarto/julia/julia_transport.txt exists, reusing server.
- Transport file read successfully.
- Connecting to server at port 8002, pid 59472
- write command "isready" to socket server
- received server response
- Transport file read successfully.
- write command "isopen" to socket server
- received server response
- write command "run" to socket server
- received server response
- received progress update response, listening for further responses
Running [1/3] at line 9:  Pkg.activate("Plots")
- received server response
- received progress update response, listening for further responses
Running [2/3] at line 14:  import Plots
- received server response
- received progress update response, listening for further responses
Running [3/3] at line 18:  Plots.plot(Plots.fakedata(50, 5), w = 3)
- received server response
- write command "close" to socket server
- received server response
pandoc 
  to: html
  output-file: Plots.html
  standalone: true
  section-divs: true
  html-math-method: mathjax
  wrap: none
  default-image-extension: png
  
metadata
  document-css: false
  link-citations: true
  date-format: long
  lang: en
  title: Plots integration
  
Output created: Plots.html

```