### PR TITLE
invokelatest expand to allow extension within notebook

### DIFF
--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -46,7 +46,7 @@ function _render_thunk(
     is_expansion = false
     if !captured.error
         try
-            expansion = expand(captured.value)
+            expansion = Base.@invokelatest expand(captured.value)
             is_expansion = _is_expanded(captured.value, expansion)
         catch error
             backtrace = catch_backtrace()


### PR DESCRIPTION
For trying out things quickly it can be nice to do `using QuartoNotebookWorker` and then overloading its `expand` function for some struct defined there.