### PR TITLE
Fix Plotly require.js config mechanism

### DIFF
--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
@@ -40,6 +40,11 @@ function Base.show(io::IO, ::MIME"text/html", p::PlotlyBasePlotWithoutRequireJS)
     PlotlyBase.to_html(io, p.plot; include_plotlyjs = "require-loaded", full_html = false)
 end
 
+Base.show(io::IO, M::MIME, p::PlotlyBasePlotWithoutRequireJS) = show(io, M, p.plot)
+Base.show(io::IO, m::MIME"text/plain", p::PlotlyBasePlotWithoutRequireJS) =
+    show(io, m, p.plot)
+Base.showable(M::MIME, p::PlotlyBasePlotWithoutRequireJS) = showable(M, p.plot)
+
 function Base.show(io::IO, ::MIME"text/html", ::PlotlyRequireJSConfig)
     print(io, PlotlyBase._requirejs_config())
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
@@ -13,7 +13,7 @@ function Base.show(io::IO, ::MIME"text/html", wrapper::PlotlyBasePlot)
     # We want to embed only the minimum markup needed to render the
     # plotlyjs plots, otherwise a full HTML page is generated for every
     # plot which does not render correctly in our context.
-    PlotlyBase.to_html(io, wrapper.value; include_plotlyjs = "require", full_html = false)
+    PlotlyBase.to_html(io, wrapper.value; include_plotlyjs = "require-loaded", full_html = false)
 end
 
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
@@ -4,16 +4,59 @@ import QuartoNotebookWorker
 import PlotlyBase
 
 QuartoNotebookWorker._mimetype_wrapper(p::PlotlyBase.Plot) = PlotlyBasePlot(p)
-
 struct PlotlyBasePlot <: QuartoNotebookWorker.WrapperType
     value::PlotlyBase.Plot
 end
 
-function Base.show(io::IO, ::MIME"text/html", wrapper::PlotlyBasePlot)
+struct PlotlyBasePlotWithoutRequireJS
+    plot::PlotlyBase.Plot
+end
+
+struct PlotlyRequireJSConfig end
+
+const FIRST_PLOT_DISPLAYED = Ref(false)
+
+function QuartoNotebookWorker.expand(p::PlotlyBasePlot)
+
+    plotcell = QuartoNotebookWorker.Cell(PlotlyBasePlotWithoutRequireJS(p.value))
+
+    # Quarto expects that the require.js preamble which Plotly needs to function
+    # comes in its own cell, which will then be hoisted into the HTML page header.
+    # So we cannot have that preamble concatenated with every plot's HTML content.
+    # Instead, e keep track whether a Plotly plot is the first per notebook, and in that
+    # case have it expand into the preamble cell and the plot cell. If it's not the
+    # first time, we expand only into the plot cell.
+    cells = if !FIRST_PLOT_DISPLAYED[]
+        [QuartoNotebookWorker.Cell(PlotlyRequireJSConfig()), plotcell]
+    else
+        [plotcell]
+    end
+
+    FIRST_PLOT_DISPLAYED[] = true
+
+    return cells
+end
+
+function Base.show(io::IO, ::MIME"text/html", p::PlotlyBasePlotWithoutRequireJS)
     # We want to embed only the minimum markup needed to render the
     # plotlyjs plots, otherwise a full HTML page is generated for every
     # plot which does not render correctly in our context.
-    PlotlyBase.to_html(io, wrapper.value; include_plotlyjs = "require-loaded", full_html = false)
+    # "require-loaded" means that we pass the require.js preamble ourselves.
+    PlotlyBase.to_html(io, p.plot; include_plotlyjs = "require-loaded", full_html = false)
+end
+
+function Base.show(io::IO, ::MIME"text/html", ::PlotlyRequireJSConfig)
+    print(io, PlotlyBase._requirejs_config())
+end
+
+function reset_first_plot_displayed_flag!()
+    FIRST_PLOT_DISPLAYED[] = false
+end
+
+function __init__()
+    if ccall(:jl_generating_output, Cint, ()) == 0
+        QuartoNotebookWorker.add_package_refresh_hook!(reset_first_plot_displayed_flag!)
+    end
 end
 
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyBaseExt.jl
@@ -3,11 +3,6 @@ module QuartoNotebookWorkerPlotlyBaseExt
 import QuartoNotebookWorker
 import PlotlyBase
 
-QuartoNotebookWorker._mimetype_wrapper(p::PlotlyBase.Plot) = PlotlyBasePlot(p)
-struct PlotlyBasePlot <: QuartoNotebookWorker.WrapperType
-    value::PlotlyBase.Plot
-end
-
 struct PlotlyBasePlotWithoutRequireJS
     plot::PlotlyBase.Plot
 end
@@ -16,9 +11,9 @@ struct PlotlyRequireJSConfig end
 
 const FIRST_PLOT_DISPLAYED = Ref(false)
 
-function QuartoNotebookWorker.expand(p::PlotlyBasePlot)
+function QuartoNotebookWorker.expand(p::PlotlyBase.Plot)
 
-    plotcell = QuartoNotebookWorker.Cell(PlotlyBasePlotWithoutRequireJS(p.value))
+    plotcell = QuartoNotebookWorker.Cell(PlotlyBasePlotWithoutRequireJS(p))
 
     # Quarto expects that the require.js preamble which Plotly needs to function
     # comes in its own cell, which will then be hoisted into the HTML page header.

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
@@ -3,6 +3,6 @@ module QuartoNotebookWorkerPlotlyJSExt
 import QuartoNotebookWorker
 import PlotlyJS
 
-QuartoNotebookWorker._mimetype_wrapper(p::PlotlyJS.SyncPlot) = QuartoNotebookWorker._mimetype_wrapper(p.plot)
+QuartoNotebookWorker.expand(p::PlotlyJS.SyncPlot) = QuartoNotebookWorker.expand(p.plot)
 
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
@@ -16,7 +16,7 @@ function Base.show(io::IO, ::MIME"text/html", wrapper::PlotlyJSSyncPlot)
     PlotlyJS.PlotlyBase.to_html(
         io,
         wrapper.value.plot;
-        include_plotlyjs = "require",
+        include_plotlyjs = "require-loaded",
         full_html = false,
     )
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerPlotlyJSExt.jl
@@ -3,22 +3,6 @@ module QuartoNotebookWorkerPlotlyJSExt
 import QuartoNotebookWorker
 import PlotlyJS
 
-QuartoNotebookWorker._mimetype_wrapper(p::PlotlyJS.SyncPlot) = PlotlyJSSyncPlot(p)
-
-struct PlotlyJSSyncPlot <: QuartoNotebookWorker.WrapperType
-    value::PlotlyJS.SyncPlot
-end
-
-function Base.show(io::IO, ::MIME"text/html", wrapper::PlotlyJSSyncPlot)
-    # We want to embed only the minimum markup needed to render the
-    # plotlyjs plots, otherwise a full HTML page is generated for every
-    # plot which does not render correctly in our context.
-    PlotlyJS.PlotlyBase.to_html(
-        io,
-        wrapper.value.plot;
-        include_plotlyjs = "require-loaded",
-        full_html = false,
-    )
-end
+QuartoNotebookWorker._mimetype_wrapper(p::PlotlyJS.SyncPlot) = QuartoNotebookWorker._mimetype_wrapper(p.plot)
 
 end

--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -47,10 +47,15 @@ function _render_thunk(
     # so we need to catch that and return an error cell if that's the case.
     expansion = nothing
     is_expansion = false
+    # Intercept objects prior to rendering so that we can wrap specific
+    # types in our own `WrapperType` to customised rendering instead of
+    # what the package defines itself.
+    # Calling the wrapping mechanism here allows it to affect expansion
+    value = Base.@invokelatest _mimetype_wrapper(captured.value)
     if !captured.error
         try
-            expansion = Base.@invokelatest expand(captured.value)
-            is_expansion = _is_expanded(captured.value, expansion)
+            expansion = Base.@invokelatest expand(value)
+            is_expansion = _is_expanded(value, expansion)
         catch error
             backtrace = catch_backtrace()
             return ((;
@@ -92,7 +97,7 @@ function _render_thunk(
         end
     else
         results = Base.@invokelatest render_mimetypes(
-            REPL.ends_with_semicolon(code) ? nothing : captured.value,
+            REPL.ends_with_semicolon(code) ? nothing : value,
             cell_options;
             inline,
         )
@@ -105,11 +110,11 @@ function _render_thunk(
             results,
             display_results,
             output = captured.output,
-            error = captured.error ? string(typeof(captured.value)) : nothing,
+            error = captured.error ? string(typeof(value)) : nothing,
             backtrace = collect(
                 eachline(
                     IOBuffer(
-                        clean_bt_str(captured.error, captured.backtrace, captured.value),
+                        clean_bt_str(captured.error, captured.backtrace, value),
                     ),
                 ),
             ),
@@ -301,11 +306,6 @@ Base.showable(mime::MIME, w::WrapperType) = Base.showable(mime, w.value)
 # for inline code chunks, `inline` should be set to `true` which causes "text/plain" output like
 # what you'd get from `print` (Strings without quotes) and not from `show("text/plain", ...)`
 function render_mimetypes(value, cell_options; inline::Bool = false)
-    # Intercept objects prior to rendering so that we can wrap specific
-    # types in our own `WrapperType` to customised rendering instead of
-    # what the package defines itself.
-    value = _mimetype_wrapper(value)
-
     to_format = NotebookState.OPTIONS[]["format"]["pandoc"]["to"]
 
     result = Dict{String,@NamedTuple{error::Bool, data::Vector{UInt8}}}()

--- a/test/testsets/integrations/PlotlyJS.jl
+++ b/test/testsets/integrations/PlotlyJS.jl
@@ -6,6 +6,13 @@ if Sys.iswindows()
 else
     test_example(joinpath(@__DIR__, "../../examples/integrations/PlotlyJS.qmd")) do json
         cells = json["cells"]
+        preamble_cell = cells[5]
+        outputs = preamble_cell["outputs"]
+        @test length(outputs) == 1
+        data = outputs[1]["data"]
+        @test keys(data) == Set(["text/html", "text/plain"])
+        @test startswith(data["text/html"], "<script type=\"text/javascript\">")
+        @test occursin("require.undef(\"plotly\")", data["text/html"])
         for nth in (6, 9)
             cell = cells[nth]
             outputs = cell["outputs"]

--- a/test/testsets/integrations/PlotlyJS.jl
+++ b/test/testsets/integrations/PlotlyJS.jl
@@ -6,7 +6,7 @@ if Sys.iswindows()
 else
     test_example(joinpath(@__DIR__, "../../examples/integrations/PlotlyJS.qmd")) do json
         cells = json["cells"]
-        for nth in (4, 6)
+        for nth in (6, 9)
             cell = cells[nth]
             outputs = cell["outputs"]
             @test length(outputs) == 1


### PR DESCRIPTION
Quarto expects the preamble for a Plotly plot using require.js to exist in a cell only once. So we keep track whether a PlotlyBase plot has already been displayed, and only if not, we expand the plot into two cells, the preamble and the plot's html.

The fix on the quarto side is not in a prerelease, yet, but locally I confirmed that this works with latest master:

````
---
engine: julia
keep-md: true
---

```{julia}
using PlotlyJS

plot(rand(10,4))
```

and another plot

```{julia}
plot(cumsum(randn(100)))
```
````

<img width="876" alt="image" src="https://github.com/PumasAI/QuartoNotebookRunner.jl/assets/22495855/8a794b11-8878-4cd9-a6b3-083af6906f16">
