### PR TITLE
Fix unpopulated notebook options during worker package init

### DIFF
--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerCairoMakieExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerCairoMakieExt.jl
@@ -14,10 +14,15 @@ function configure()
         kwargs = Dict{Symbol,Any}()
     end
     if fm.fig_format == "pdf"
-        CairoMakie.activate!(; type = "png", kwargs...)
+        kwargs[:type] = "png"
     else
-        CairoMakie.activate!(; type = fm.fig_format, kwargs...)
+        if isa(fm.fig_format, AbstractString)
+            kwargs[:type] = fm.fig_format
+        end
     end
+    CairoMakie.activate!(; kwargs...)
+
+    return nothing
 end
 
 function __init__()

--- a/src/QuartoNotebookWorker/src/NotebookState.jl
+++ b/src/QuartoNotebookWorker/src/NotebookState.jl
@@ -11,6 +11,7 @@ const CELL_OPTIONS = Ref(Dict{String,Any}())
 function __init__()
     if ccall(:jl_generating_output, Cint, ()) == 0
         PROJECT[] = Base.active_project()
+        OPTIONS[] = task_local_storage(:QUARTO_NOTEBOOK_WORKER_OPTIONS, Dict{String,Any}())
         define_notebook_module!()
     end
 end

--- a/src/QuartoNotebookWorker/src/refresh.jl
+++ b/src/QuartoNotebookWorker/src/refresh.jl
@@ -24,13 +24,25 @@ function refresh!(path, original_options, options = original_options)
     return nothing
 end
 
+function rget(dict, keys, default)
+    value = dict
+    for key in keys
+        if haskey(value, key)
+            value = value[key]
+        else
+            return default
+        end
+    end
+    return value
+end
+
 function _figure_metadata()
     options = NotebookState.OPTIONS[]
 
-    fig_width_inch = options["format"]["execute"]["fig-width"]
-    fig_height_inch = options["format"]["execute"]["fig-height"]
-    fig_format = options["format"]["execute"]["fig-format"]
-    fig_dpi = options["format"]["execute"]["fig-dpi"]
+    fig_width_inch = rget(options, ("format", "execute", "fig-width"), nothing)
+    fig_height_inch = rget(options, ("format", "execute", "fig-height"), nothing)
+    fig_format = rget(options, ("format", "execute", "fig-format"), nothing)
+    fig_dpi = rget(options, ("format", "execute", "fig-dpi"), nothing)
 
     if fig_format == "retina"
         fig_format = "svg"

--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -326,7 +326,8 @@ function render_mimetypes(value, cell_options; inline::Bool = false)
     # what the package defines itself.
     value = _mimetype_wrapper(value)
 
-    to_format = NotebookState.OPTIONS[]["format"]["pandoc"]["to"]
+    options = NotebookState.OPTIONS[]
+    to_format = rget(options, ("format", "pandoc", "to"), nothing)
 
     result = Dict{String,@NamedTuple{error::Bool, data::Vector{UInt8}}}()
     # Some output formats that we want to write to need different

--- a/src/QuartoNotebookWorker/test/runtests.jl
+++ b/src/QuartoNotebookWorker/test/runtests.jl
@@ -4,4 +4,10 @@ using Test, QuartoNotebookWorker
     # Just a dummy test for now. We can start adding real tests in follow-up PRs
     # that make changes to the worker code.
     @test QuartoNotebookWorker.Packages.is_precompiling() == false
+    @test QuartoNotebookWorker._figure_metadata() == (
+        fig_width_inch = nothing,
+        fig_height_inch = nothing,
+        fig_format = nothing,
+        fig_dpi = nothing,
+    )
 end

--- a/src/WorkerSetup.jl
+++ b/src/WorkerSetup.jl
@@ -245,11 +245,13 @@ function test(; exeflags = String[])
         write(
             file,
             """
+            pushfirst!(LOAD_PATH, "@stdlib")
+            import Pkg
+            popfirst!(LOAD_PATH)
+
             cd($(repr(QNW)))
 
             pushfirst!(LOAD_PATH, $(repr(project)))
-
-            import Pkg
             Pkg.test("QuartoNotebookWorker")
             """,
         )

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -4,12 +4,14 @@ function worker_init(f::File, options::Dict)
         return quote
             push!(LOAD_PATH, $(project))
 
-            let QNW = Base.require(
-                    Base.PkgId(
-                        Base.UUID("38328d9c-a911-4051-bc06-3f7f556ffeda"),
-                        "QuartoNotebookWorker",
-                    ),
-                )
+            let QNW = task_local_storage(:QUARTO_NOTEBOOK_WORKER_OPTIONS, $(options)) do
+                    Base.require(
+                        Base.PkgId(
+                            Base.UUID("38328d9c-a911-4051-bc06-3f7f556ffeda"),
+                            "QuartoNotebookWorker",
+                        ),
+                    )
+                end
                 global refresh!(args...) = QNW.refresh!($(f.path), $(options), args...)
                 global render(args...; kwargs...) = QNW.render(args...; kwargs...)
             end

--- a/test/worker_tests.jl
+++ b/test/worker_tests.jl
@@ -1,0 +1,6 @@
+using Test
+import QuartoNotebookRunner
+
+@testset "QuartoNotebookWorker" begin
+    @test success(QuartoNotebookRunner.WorkerSetup.test())
+end


### PR DESCRIPTION
Handles the case where a package that triggers extension loading within this package's worker package is already available in the process that is running the notebook (e.g. a system image containing `Makie`).