### PR TITLE
Fix global `eval: false`

### DIFF
--- a/test/examples/evalfalse.qmd
+++ b/test/examples/evalfalse.qmd
@@ -1,0 +1,21 @@
+---
+title: Cell Options
+engine: julia
+execute:
+    eval: false
+---
+
+```{julia}
+println("shouldn't run")
+```
+
+```{julia}
+#| eval: false
+println("shouldn't run either")
+```
+
+```{julia}
+#| eval: true
+println("should run")
+```
+

--- a/test/testsets/evalfalse.jl
+++ b/test/testsets/evalfalse.jl
@@ -1,0 +1,10 @@
+include("../utilities/prelude.jl")
+
+test_example(joinpath(@__DIR__, "../examples/evalfalse.qmd")) do json
+    cells = json["cells"]
+    @test length(cells) == 7
+    @test isempty(cells[2]["outputs"])
+    @test isempty(cells[4]["outputs"])
+    @test !isempty(cells[6]["outputs"])
+    @test occursin("should run", cells[6]["outputs"][1]["text"])
+end


### PR DESCRIPTION
Fixes #173 

If `eval: false` is set globally, either via frontmatter or through quarto, only cells which explicitly have `eval: true` set will be evaluated.