### PR TITLE
Fix Julia 1.11 errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         version:
           - "1.6"
-          - "1.10"
+          - "1.11"
         os:
           - ubuntu-latest
           - macos-13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,10 +58,16 @@ jobs:
             os: macos-13
           - version: "1.6"
             os: windows-latest
+          # Performance regressions on Julia 1.11 on Windows. Currently not
+          # viable to run the test suite there.
+          - version: "1.11"
+            os: windows-latest
         include:
           - version: "1.7"
             os: macos-13
           - version: "1.7"
+            os: windows-latest
+          - version: "1.10"
             os: windows-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/src/QuartoNotebookWorker/src/NotebookState.jl
+++ b/src/QuartoNotebookWorker/src/NotebookState.jl
@@ -12,7 +12,6 @@ function __init__()
     if ccall(:jl_generating_output, Cint, ()) == 0
         PROJECT[] = Base.active_project()
         OPTIONS[] = task_local_storage(:QUARTO_NOTEBOOK_WORKER_OPTIONS, Dict{String,Any}())
-        define_notebook_module!()
     end
 end
 

--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -122,9 +122,20 @@ end
 # Setting the `helpmode` module isn't an option on Julia 1.6 so we need to
 # manually replace `Main` with the module we want.
 function _helpmode(code::AbstractString, mod::Module)
-    ex = REPL.helpmode(code)
-    return postwalk(ex) do x
-        return x == Main ? mod : x
+    @static if VERSION < v"1.11.0"
+        ex = REPL.helpmode(code)
+        ex = postwalk(ex) do x
+            return x == Main ? mod : x
+        end
+        # helpmode embeds object references to `stdout` into the expression, but
+        # since we are capturing the output it refers to a different stream. We
+        # need to replace the first `stdout` reference with `:stdout` and remove
+        # the argument from the other call so that it uses the redirected one.
+        ex.args[2] = :stdout
+        deleteat!(ex.args[end].args, 3)
+        return ex
+    else
+        return :(Core.eval($(mod), $(REPL).helpmode(stdout, $(code), $(mod))))
     end
 end
 
@@ -138,15 +149,6 @@ function _process_code(
     if startswith(code, help_regex)
         code = String(chomp(replace(code, help_regex => ""; count = 1)))
         ex = _helpmode(code, mod)
-
-        # helpmode embeds object references to `stdout` into the
-        # expression, but since we are capturing the output it refers to
-        # a different stream. We need to replace the first `stdout`
-        # reference with `:stdout` and remove the argument from the
-        # other call so that it uses the redirected one.
-        ex.args[2] = :stdout
-        deleteat!(ex.args[end].args, 3)
-
         return Expr(:toplevel, ex)
     end
 
@@ -166,19 +168,16 @@ function _process_code(
     pkg_regex = r"^\s*\]"
     if startswith(code, pkg_regex)
         code = String(chomp(replace(code, pkg_regex => ""; count = 1)))
-        return Expr(
-            :toplevel,
-            :(
-                let printed = $(Pkg).REPLMode.PRINTED_REPL_WARNING[]
-                    $(Pkg).REPLMode.PRINTED_REPL_WARNING[] = true
-                    try
-                        $(Pkg).REPLMode.do_cmd($(Pkg).REPLMode.MiniREPL(), $code)
-                    finally
-                        $(Pkg).REPLMode.PRINTED_REPL_WARNING[] = printed
-                    end
+        return Expr(:toplevel, :(
+            let printed = $(Pkg).REPLMode.PRINTED_REPL_WARNING[]
+                $(Pkg).REPLMode.PRINTED_REPL_WARNING[] = true
+                try
+                    $(Pkg).REPLMode.@pkg_str $code
+                finally
+                    $(Pkg).REPLMode.PRINTED_REPL_WARNING[] = printed
                 end
-            ),
-        )
+            end
+        ))
     end
 
     return _parseall(code; filename, lineno)

--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -119,10 +119,11 @@ function _render_thunk(
     end
 end
 
-# Setting the `helpmode` module isn't an option on Julia 1.6 so we need to
-# manually replace `Main` with the module we want.
 function _helpmode(code::AbstractString, mod::Module)
     @static if VERSION < v"1.11.0"
+        # Earlier versions of Julia don't have the `helpmode` method that takes
+        # `io`, `code`, `mod` and so we have to manually alter the returned
+        # expression instead.
         ex = REPL.helpmode(code)
         ex = postwalk(ex) do x
             return x == Main ? mod : x

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -25,6 +25,7 @@ function worker_init(f::File, options::Dict)
                         ),
                     )
                 end
+                QNW.NotebookState.define_notebook_module!(Main)
                 global refresh!(args...) = QNW.refresh!($(f.path), $(options), args...)
                 global render(args...; kwargs...) = QNW.render(args...; kwargs...)
             end


### PR DESCRIPTION
Fixes #190.

There's a number of other test failures due to assumptions hardcoded in specific tests that will also need to be addressed before CI will pass.