### PR TITLE
Append user exeflags to env exeflags

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -64,7 +64,8 @@ function _extract_timeout(merged_options)
 end
 
 function _exeflags_and_env(options)
-    env_exeflags = JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_EXEFLAGS", "[]"), Vector{String})
+    env_exeflags =
+        JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_EXEFLAGS", "[]"), Vector{String})
     options_exeflags = map(String, options["format"]["metadata"]["julia"]["exeflags"])
     # We want to be able to override exeflags that are defined via environment variable,
     # but leave the remaining flags intact (for example override number of threads but leave sysimage).

--- a/src/server.jl
+++ b/src/server.jl
@@ -547,7 +547,7 @@ function default_frontmatter()
     env = JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_ENV", "[]"), Vector{String})
     return D(
         "fig-format" => "png",
-        "julia" => D("env" => env),
+        "julia" => D("env" => env, "exeflags" => []),
         "execute" => D("error" => true),
     )
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -64,7 +64,13 @@ function _extract_timeout(merged_options)
 end
 
 function _exeflags_and_env(options)
-    exeflags = map(String, options["format"]["metadata"]["julia"]["exeflags"])
+    env_exeflags = JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_EXEFLAGS", "[]"), Vector{String})
+    options_exeflags = map(String, options["format"]["metadata"]["julia"]["exeflags"])
+    # We want to be able to override exeflags that are defined via environment variable,
+    # but leave the remaining flags intact (for example override number of threads but leave sysimage).
+    # We can do this by adding the options exeflags after the env exeflags.
+    # Julia will ignore earlier uses of the same flag.
+    exeflags = [env_exeflags; options_exeflags]
     env = map(String, options["format"]["metadata"]["julia"]["env"])
     # Use `--project=@.` if neither `JULIA_PROJECT=...` nor `--project=...` are specified
     if !any(startswith("JULIA_PROJECT="), env) && !any(startswith("--project="), exeflags)
@@ -537,11 +543,10 @@ end
 
 function default_frontmatter()
     D = Dict{String,Any}
-    exeflags = JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_EXEFLAGS", "[]"), Vector{String})
     env = JSON3.read(get(ENV, "QUARTONOTEBOOKRUNNER_ENV", "[]"), Vector{String})
     return D(
         "fig-format" => "png",
-        "julia" => D("exeflags" => exeflags, "env" => env),
+        "julia" => D("env" => env),
         "execute" => D("error" => true),
     )
 end

--- a/test/examples/exeflags_merging.qmd
+++ b/test/examples/exeflags_merging.qmd
@@ -1,0 +1,14 @@
+---
+title: Exeflags merging
+engine: julia
+julia:
+    exeflags: []
+---
+
+```{julia}
+print(Base.active_project())
+```
+
+```{julia}
+print(Threads.nthreads())
+```

--- a/test/testsets/exeflags_merging.jl
+++ b/test/testsets/exeflags_merging.jl
@@ -1,0 +1,41 @@
+include("../utilities/prelude.jl")
+
+@testset "exeflags merging" begin
+
+    function with_replacement_file(f, file, replacements...)
+        s = read(file, String)
+        mktempdir() do dir
+            tempfile = joinpath(dir, basename(file))
+            open(tempfile, "w") do io
+                write(io, replace(s, replacements...))
+            end
+            f(tempfile)
+        end
+    end
+
+    file = joinpath(@__DIR__, "../examples/exeflags_merging.qmd")
+
+    withenv("QUARTONOTEBOOKRUNNER_EXEFLAGS" => "[\"--project=/set_via_env\", \"--threads=3\"]") do
+        server = QuartoNotebookRunner.Server()
+        json = QuartoNotebookRunner.run!(server, file; showprogress = false)
+        @test contains(json.cells[2].outputs[1].text, "set_via_env")
+        @test json.cells[4].outputs[1].text == "3"
+        close!(server)
+
+        with_replacement_file(file, "[]" => "[\"--project=/override_via_frontmatter\"]") do newfile
+            server = QuartoNotebookRunner.Server()
+            json = QuartoNotebookRunner.run!(server, newfile; showprogress = false)
+            @test contains(json.cells[2].outputs[1].text, "override_via_frontmatter")
+            @test json.cells[4].outputs[1].text == "3"
+            close!(server)
+        end
+
+        with_replacement_file(file, "[]" => "[\"--threads=5\"]") do newfile
+            server = QuartoNotebookRunner.Server()
+            json = QuartoNotebookRunner.run!(server, newfile; showprogress = false)
+            @test contains(json.cells[2].outputs[1].text, "set_via_env")
+            @test json.cells[4].outputs[1].text == "5"
+            close!(server)
+        end
+    end
+end

--- a/test/testsets/exeflags_merging.jl
+++ b/test/testsets/exeflags_merging.jl
@@ -15,14 +15,19 @@ include("../utilities/prelude.jl")
 
     file = joinpath(@__DIR__, "../examples/exeflags_merging.qmd")
 
-    withenv("QUARTONOTEBOOKRUNNER_EXEFLAGS" => "[\"--project=/set_via_env\", \"--threads=3\"]") do
+    withenv(
+        "QUARTONOTEBOOKRUNNER_EXEFLAGS" => "[\"--project=/set_via_env\", \"--threads=3\"]",
+    ) do
         server = QuartoNotebookRunner.Server()
         json = QuartoNotebookRunner.run!(server, file; showprogress = false)
         @test contains(json.cells[2].outputs[1].text, "set_via_env")
         @test json.cells[4].outputs[1].text == "3"
         close!(server)
 
-        with_replacement_file(file, "[]" => "[\"--project=/override_via_frontmatter\"]") do newfile
+        with_replacement_file(
+            file,
+            "[]" => "[\"--project=/override_via_frontmatter\"]",
+        ) do newfile
             server = QuartoNotebookRunner.Server()
             json = QuartoNotebookRunner.run!(server, newfile; showprogress = false)
             @test contains(json.cells[2].outputs[1].text, "override_via_frontmatter")


### PR DESCRIPTION
Changes the behavior of the `QUARTONOTEBOOKRUNNER_EXEFLAGS` env variable in conjunction with the `exeflags` frontmatter variable.

Before, the env variable would only have an effect if no frontmatter variable was specified. Frontmatter exeflags would fully override env exeflags. This is impractical if the env specifies a sysimage to use system-wide but a user wants to change only the number of threads for some notebook.

Therefore, this PR appends the user-specified exeflags to the env-specified ones. This has the effect of merging them as Julia ignores earlier instances of the same flags.