### PR TITLE
Fix #249, color printing of cell results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - QuartoNotebookRunner now corrects the png image size metadata it reports to quarto by the dpi stored in the file, if available. This will result in smaller visual image sizes for files with dpi > 96 [#248].
 
+### Fixed
+
+- Fix printing of cell results that contain color [#250]
+
 ## [v0.12.1] - 2025-02-04
 
 ### Fixed
@@ -346,3 +350,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#232]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/232
 [#238]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/238
 [#248]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/248
+[#250]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/250

--- a/src/QuartoNotebookWorker/src/render.jl
+++ b/src/QuartoNotebookWorker/src/render.jl
@@ -269,6 +269,7 @@ function _io_context(cell_options = Dict{String,Any}())
     return [
         :module => NotebookState.notebook_module(),
         :limit => true,
+        :color => Base.have_color,
         # This allows a `show` method implementation to check for
         # metadata that may be of relevance to it's rendering. For
         # example, if a `typst` table is rendered with a caption

--- a/test/examples/stdout.qmd
+++ b/test/examples/stdout.qmd
@@ -30,3 +30,11 @@ Logging:
 ```{julia}
 @error "error text" value=3
 ```
+
+```{julia}
+struct Color
+    text::String
+end
+Base.show(io::IO, c::Color) = printstyled(io, c.text; color = :red)
+Color("red")
+```

--- a/test/testsets/stdout.jl
+++ b/test/testsets/stdout.jl
@@ -1,7 +1,7 @@
 include("../utilities/prelude.jl")
 
 test_example(joinpath(@__DIR__, "../examples/stdout.qmd")) do json
-    @test length(json["cells"]) == 12
+    @test length(json["cells"]) == 14
 
     cell = json["cells"][1]
     @test cell["cell_type"] == "markdown"
@@ -71,4 +71,7 @@ test_example(joinpath(@__DIR__, "../examples/stdout.qmd")) do json
     @test contains(cell["outputs"][1]["text"], "Error:")
     @test contains(cell["outputs"][1]["text"], "error text")
     @test contains(cell["outputs"][1]["text"], "value = 3")
+
+    cell = json["cells"][14]
+    @test cell["outputs"][1]["data"]["text/plain"] == "\e[31mred\e[39m"
 end


### PR DESCRIPTION
Fixes #249 by passing the process color setting to the `IOContext` that handles printing cell results.

The issue example now shows as below for me: <img width="841" alt="image" src="https://github.com/user-attachments/assets/ab1f6856-b9de-4169-b5fd-940ac0d1729a" />

@ajinkya-k if you're able to confirm this fixes it for you locally that would be great, thanks.
