### PR TITLE
Fix #251, add `display` method for `InlineDisplay` with `MIME` (fixes `PrettyTables` rendering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix rendering of `PrettyTables` tables [#253]
+
 ## [v0.12.2] - 2025-02-07
 
 ### Added
@@ -354,3 +358,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#238]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/238
 [#248]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/248
 [#250]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/250
+[#253]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/253

--- a/src/QuartoNotebookWorker/src/InlineDisplay.jl
+++ b/src/QuartoNotebookWorker/src/InlineDisplay.jl
@@ -13,6 +13,11 @@ struct InlineDisplay <: AbstractDisplay
     end
 end
 
+function Base.display(d::InlineDisplay, mime::MIME, x)
+    only = string(mime)
+    push!(d.queue, Base.@invokelatest render_mimetypes(x, d.cell_options; only))
+    return nothing
+end
 function Base.display(d::InlineDisplay, x)
     push!(d.queue, Base.@invokelatest render_mimetypes(x, d.cell_options))
     return nothing

--- a/test/examples/display-mime.qmd
+++ b/test/examples/display-mime.qmd
@@ -1,0 +1,11 @@
+---
+title: Display specific MIME types
+---
+
+```{julia}
+display(MIME("text/html"), HTML("<p></p>"))
+```
+
+```{julia}
+display("text/html", HTML("<p></p>"))
+```

--- a/test/testsets/display-mime.jl
+++ b/test/testsets/display-mime.jl
@@ -1,0 +1,13 @@
+include("../utilities/prelude.jl")
+
+test_example(joinpath(@__DIR__, "../examples/display-mime.qmd")) do json
+    cells = json["cells"]
+    @test length(cells) == 4
+    for each in (2, 4)
+        cell = cells[each]
+        outputs = cell["outputs"]
+        @test length(outputs) == 1
+        text_html = outputs[1]["data"]["text/html"]
+        @test text_html == "<p></p>"
+    end
+end


### PR DESCRIPTION
Should resolve the issue found in #251. Thanks for reporting that @pierrethiriet.

Before this change our custom `InlineDisplay` that catches all `display` calls in cells and displays them to the correct IO did not have a dispatch for `display(::MIME, value)`, only `display(value)` was intercepted.

---

**Details:**

`PrettyTables` uses https://github.com/ronisbr/PrettyTables.jl/blob/99595fcad38a5181e5888e32267cd045fa5b8669/src/backends/html/html_backend.jl#L517 to print to the right place for HTML output. There is no equivalent in the LaTeX backend for that package though, so setting the backend to LaTeX ends up just printing the output to `stdout`. Luckily it appears that Quarto is able to translate HTML tables that `PrettyTables` generates into suitable LaTeX reasonably well, so just setting `--to=pdf` during rendering is sufficient to get rendered tables in a PDF.

cc @ronisbr in case you have anything to input on the difference between the rendering of HTML and LaTeX backends in `PrettyTables`?