### PR TITLE
Fix #256, adjust `startup.jl` to avoid unresolved environments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,8 +39,6 @@ jobs:
       contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
-    env:
-      JULIA_CONDAPKG_BACKEND: "Null"
     strategy:
       fail-fast: false
       matrix:
@@ -100,10 +98,6 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@8776aaf3ebefdda84c7654715823a205d047802a # v2.1.7
         with:
           version: pre-release
-
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-        with:
-          python-version: '3.13'
 
       - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
       - uses: julia-actions/julia-runtest@678da69444cd5f13d7e674a90cb4f534639a14f9 # v1.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Adjust notebook startup script to ensure all environments in `LOAD_PATH` are resolved [#257]
+
 ## [v0.13.0] - 2025-02-18
 
 ### Added
@@ -370,3 +374,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#250]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/250
 [#253]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/253
 [#255]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/255
+[#257]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/257

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -3,42 +3,6 @@
 
 # Step 1:
 #
-# Inject a sandbox environment into the `LOAD_PATH` such that it gets picked up
-# as the active project if there isn't one found in the rest of the
-# `LOAD_PATH`.
-#
-# It needs to appear ahead of the `QuartoNotebookWorker` environment so that it
-# shadows that environment since that is not a user-facing project directory,
-# and if a user was to perform `Pkg` operations they may affect that
-# environment. Instead we provide a temporary sandbox environment that gets
-# discarded when the notebook process exits.
-let sandbox = joinpath(mktempdir(), "QuartoSandbox")
-    mkpath(sandbox)
-    # The empty project file is key to making this the active environment if
-    # noting else is available if the rest of the `LOAD_PATH`.
-    touch(joinpath(sandbox, "Project.toml"))
-    push!(LOAD_PATH, sandbox)
-end
-
-# Step 2:
-#
-# This contains the worker package environment. It gets added to the LOAD_PATH
-# so that we can `require` it further down this file.
-push!(LOAD_PATH, ENV["QUARTONOTEBOOKWORKER_PACKAGE"])
-
-# Step 3:
-#
-# We also need to ensure that `@stdlib` is available on the LOAD_PATH so that
-# requiring the worker package does not attempt to load stdlib packages from
-# the wrong `julia` version. The errors that get thrown when this happens look
-# like deserialization errors due to differences in struct definitions, or
-# method signatures between different versions of Julia. This happens with
-# running `Pkg.test`, which drops `@stdlib` from the load path, but does not
-# happen if using `TestEnv.jl` to run tests in a REPL session via `include`.
-pushfirst!(LOAD_PATH, "@stdlib")
-
-# Step 4:
-#
 # Writes the error and stacktrace to the parent-provided log file rather than
 # stderr. An alternative would be to capture stderr from the parent when
 # starting this process, but then that swallows all stderr from then on. We
@@ -59,7 +23,65 @@ function capture(func)
     end
 end
 
-# Step 5:
+# Step 1:
+#
+# We need to ensure that `@stdlib` is available on the LOAD_PATH so that
+# requiring the worker package does not attempt to load stdlib packages from
+# the wrong `julia` version. The errors that get thrown when this happens look
+# like deserialization errors due to differences in struct definitions, or
+# method signatures between different versions of Julia. This happens with
+# running `Pkg.test`, which drops `@stdlib` from the load path, but does not
+# happen if using `TestEnv.jl` to run tests in a REPL session via `include`.
+pushfirst!(LOAD_PATH, "@stdlib")
+
+# Step 2:
+#
+# Inject a sandbox environment into the `LOAD_PATH` such that it gets picked up
+# as the active project if there isn't one found in the rest of the
+# `LOAD_PATH`.
+#
+# It needs to appear ahead of the `QuartoNotebookWorker` environment so that it
+# shadows that environment since that is not a user-facing project directory,
+# and if a user was to perform `Pkg` operations they may affect that
+# environment. Instead we provide a temporary sandbox environment that gets
+# discarded when the notebook process exits.
+let temp = mktempdir()
+    sandbox = joinpath(temp, "QuartoSandbox")
+    mkpath(sandbox)
+    # The empty project file is key to making this the active environment if
+    # noting else is available if the rest of the `LOAD_PATH`.
+    touch(joinpath(sandbox, "Project.toml"))
+    push!(LOAD_PATH, sandbox)
+
+    # Step 2b:
+    #
+    # We also need to ensure that the `QuartoNotebookWorker` package is
+    # available on the `LOAD_PATH`. This is done by creating another
+    # environment alongside the sandbox environment. We `Pkg.develop` the
+    # "local" `QuartoNotebookWorker` package into this environment. `Pkg`
+    # operations are logged to the `pkg.log` file that the server process can
+    # read to provide feedback to the user if needed.
+    capture() do
+        worker = joinpath(temp, "QuartoNotebookWorker")
+        mkpath(worker)
+        push!(LOAD_PATH, worker)
+        open(joinpath(ENV["MALT_WORKER_TEMP_DIR"], "pkg.log"), "w") do io
+            ap = Base.active_project()
+            id = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
+            Pkg = Base.require(id)
+            try
+                Pkg.activate(worker; io)
+                Pkg.develop(; path = ENV["QUARTONOTEBOOKWORKER_PACKAGE"], io)
+            finally
+                # Ensure that we switch the active project back afterwards.
+                Pkg.activate(ap; io)
+            end
+            flush(io)
+        end
+    end
+end
+
+# Step 3:
 #
 # The parent process needs some additional metadata about this `julia` process to
 # be able to provide relevant error messages to the user.
@@ -86,7 +108,7 @@ capture() do
     end
 end
 
-# Step 6:
+# Step 4:
 #
 # Now load in the worker package. This may trigger package precompilation on
 # first load, hence it is run under a `capture` should it fail to run.
@@ -99,13 +121,13 @@ const QuartoNotebookWorker = capture() do
     )
 end
 
-# Step 7:
+# Step 5:
 #
 # Ensures that the LOAD_PATH is returned to it's previous state without the
 # `@stdlib` that was pushed to it near the start of the file.
 popfirst!(LOAD_PATH)
 
-# Step 8:
+# Step 6:
 #
 # This calls into the main socket server loop, which does not terminate until
 # the process is finished off and the notebook needs closing. So anything

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -61,14 +61,16 @@ let temp = mktempdir()
     # "local" `QuartoNotebookWorker` package into this environment. `Pkg`
     # operations are logged to the `pkg.log` file that the server process can
     # read to provide feedback to the user if needed.
+    #
+    # `Pkg` is loaded outside of this closure otherwise the methods required do
+    # not exist in a new enough world age to be callable.
+    Pkg = Base.require(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"))
     capture() do
         worker = joinpath(temp, "QuartoNotebookWorker")
         mkpath(worker)
         push!(LOAD_PATH, worker)
         open(joinpath(ENV["MALT_WORKER_TEMP_DIR"], "pkg.log"), "w") do io
             ap = Base.active_project()
-            id = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
-            Pkg = Base.require(id)
             try
                 Pkg.activate(worker; io)
                 Pkg.develop(; path = ENV["QUARTONOTEBOOKWORKER_PACKAGE"], io)


### PR DESCRIPTION
Adjusts the behaviour of the `startup.jl` script that initialises worker processes and loads the `QuartoNotebookWorker` package into the process. Previously this was done by simply adding the worker package's path to `LOAD_PATH`, with no `Pkg` resolving to create a usable `Manifest.toml`. This was fine since it wasn't at the start of the load path, but #256 revealed that `PythonCall` introspects all entries in the load path to find it's dependencies. Unresolved environments in the load path threw an error when `Pkg.dependencies()` was called.

Instead we now call `Pkg.develop` to create a new environment that includes `QuartoNotebookWorker` as a dependency. This has the same effect as the original startup script, but ensures that all entries we add to the load path are fully resolved.