### PR TITLE
Pin `Makie` version, fixes CI failures

### DIFF
--- a/test/examples/integrations/CairoMakie/Project.toml
+++ b/test/examples/integrations/CairoMakie/Project.toml
@@ -1,2 +1,6 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+
+[compat]
+Makie = "= 0.22.1"

--- a/test/examples/mimetypes/Project.toml
+++ b/test/examples/mimetypes/Project.toml
@@ -2,4 +2,8 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+
+[compat]
+Makie = "= 0.22.1"


### PR DESCRIPTION
Until the test failures related to upstream changes are resolved @jkrumbiegel I'm just going to pin the version so that queued PRs are mergable.