### PR TITLE
Unpin Makie and fix tests

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -1338,7 +1338,7 @@ function process_results(dict::Dict{String,@NamedTuple{error::Bool, data::Vector
     return (; data, metadata, errors)
 end
 
-function png_image_metadata(bytes::Vector{UInt8})
+function png_image_metadata(bytes::Vector{UInt8}; phys_correction = true)
     if @view(bytes[1:8]) != b"\x89PNG\r\n\x1a\n"
         throw(ArgumentError("Not a png file"))
     end
@@ -1371,25 +1371,27 @@ function png_image_metadata(bytes::Vector{UInt8})
     width = Int(_load(UInt32, chunk.data, 1))
     height = Int(_load(UInt32, chunk.data, 5))
 
-    # if the png reports a physical pixel size, i.e., it has a pHYs chunk
-    # with the pixels per meter unit flag set, correct the basic width and height
-    # by those physical pixel sizes so that quarto receives the intended size
-    # in CSS pixels
-    while true
-        chunk = read_chunk!()
-        chunk === nothing && break
-        chunk.type == b"IDAT" && break
-        if chunk.type == b"pHYs"
-            is_in_meters = Bool(_load(UInt8, chunk.data, 9))
-            is_in_meters || break
-            x_px_per_meter = _load(UInt32, chunk.data, 1)
-            y_px_per_meter = _load(UInt32, chunk.data, 5)
-            # it seems sensible to round the final image size to full CSS pixels,
-            # especially given that png doesn't store dpi but px per meter
-            # in an integer format, losing some precision
-            width = round(Int, width / x_px_per_meter * (96 / 0.0254))
-            height = round(Int, height / y_px_per_meter * (96 / 0.0254))
-            break
+    if phys_correction
+        # if the png reports a physical pixel size, i.e., it has a pHYs chunk
+        # with the pixels per meter unit flag set, correct the basic width and height
+        # by those physical pixel sizes so that quarto receives the intended size
+        # in CSS pixels
+        while true
+            chunk = read_chunk!()
+            chunk === nothing && break
+            chunk.type == b"IDAT" && break
+            if chunk.type == b"pHYs"
+                is_in_meters = Bool(_load(UInt8, chunk.data, 9))
+                is_in_meters || break
+                x_px_per_meter = _load(UInt32, chunk.data, 1)
+                y_px_per_meter = _load(UInt32, chunk.data, 5)
+                # it seems sensible to round the final image size to full CSS pixels,
+                # especially given that png doesn't store dpi but px per meter
+                # in an integer format, losing some precision
+                width = round(Int, width / x_px_per_meter * (96 / 0.0254))
+                height = round(Int, height / y_px_per_meter * (96 / 0.0254))
+                break
+            end
         end
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/examples/integrations/CairoMakie.qmd
+++ b/test/examples/integrations/CairoMakie.qmd
@@ -17,3 +17,7 @@ import CairoMakie
 ```{julia}
 CairoMakie.scatter([1, 2, 3], [1, 2, 3])
 ```
+
+```{julia}
+CairoMakie.Makie.current_default_theme()[:CairoMakie][:px_per_unit][]
+```

--- a/test/examples/integrations/CairoMakie.qmd
+++ b/test/examples/integrations/CairoMakie.qmd
@@ -17,7 +17,3 @@ import CairoMakie
 ```{julia}
 CairoMakie.scatter([1, 2, 3], [1, 2, 3])
 ```
-
-```{julia}
-CairoMakie.Makie.current_default_theme()[:CairoMakie][:px_per_unit][]
-```

--- a/test/examples/integrations/CairoMakie/Project.toml
+++ b/test/examples/integrations/CairoMakie/Project.toml
@@ -1,6 +1,2 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-
-[compat]
-Makie = "= 0.22.1"

--- a/test/examples/mimetypes/Project.toml
+++ b/test/examples/mimetypes/Project.toml
@@ -2,8 +2,4 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-
-[compat]
-Makie = "= 0.22.1"

--- a/test/testsets/integrations/CairoMakie.jl
+++ b/test/testsets/integrations/CairoMakie.jl
@@ -11,8 +11,6 @@ test_example(joinpath(@__DIR__, "../../examples/integrations/CairoMakie.qmd")) d
           Dict("width" => 4 * px_per_inch, "height" => 3 * px_per_inch)
 
     pngbytes = Base64.base64decode(cell["outputs"][1]["data"]["image/png"])
-    @test QuartoNotebookRunner.png_image_metadata(
-        pngbytes;
-        phys_correction = false,
-    ) == (; width = 4 * 150, height = 3 * 150)
+    @test QuartoNotebookRunner.png_image_metadata(pngbytes; phys_correction = false) ==
+          (; width = 4 * 150, height = 3 * 150)
 end

--- a/test/testsets/integrations/CairoMakie.jl
+++ b/test/testsets/integrations/CairoMakie.jl
@@ -10,8 +10,9 @@ test_example(joinpath(@__DIR__, "../../examples/integrations/CairoMakie.qmd")) d
     @test cell["outputs"][1]["metadata"]["image/png"] ==
           Dict("width" => 4 * px_per_inch, "height" => 3 * px_per_inch)
 
-    # the pixel resolution is controlled by px_per_unit and that reflects the dpi that is set
-    px_per_unit_str = cells[end-1]["outputs"][1]["data"]["text/plain"]
-    px_per_unit = parse(Float64, px_per_unit_str)
-    @test px_per_unit == 150 / px_per_inch
+    pngbytes = Base64.base64decode(cell["outputs"][1]["data"]["image/png"])
+    @test QuartoNotebookRunner.png_image_metadata(
+        pngbytes;
+        phys_correction = false,
+    ) == (; width = 4 * 150, height = 3 * 150)
 end

--- a/test/testsets/integrations/CairoMakie.jl
+++ b/test/testsets/integrations/CairoMakie.jl
@@ -3,6 +3,15 @@ include("../../utilities/prelude.jl")
 test_example(joinpath(@__DIR__, "../../examples/integrations/CairoMakie.qmd")) do json
     cells = json["cells"]
     cell = cells[6]
+
+    px_per_inch = 96
+
+    # the size metadata is just inches converted to CSS pixels, independent of pixel resolution
     @test cell["outputs"][1]["metadata"]["image/png"] ==
-          Dict("width" => 4 * 150, "height" => 3 * 150)
+          Dict("width" => 4 * px_per_inch, "height" => 3 * px_per_inch)
+
+    # the pixel resolution is controlled by px_per_unit and that reflects the dpi that is set
+    px_per_unit_str = cells[end-1]["outputs"][1]["data"]["text/plain"]
+    px_per_unit = parse(Float64, px_per_unit_str)
+    @test px_per_unit == 150 / px_per_inch
 end

--- a/test/testsets/package_integration_hooks.jl
+++ b/test/testsets/package_integration_hooks.jl
@@ -27,12 +27,17 @@ include("../utilities/prelude.jl")
                     showprogress = false,
                 )
                 logical_size = json.cells[end-1].outputs[1].metadata["image/png"]
-                pngbytes = Base64.base64decode(json.cells[end-1].outputs[1].data["image/png"])
+                pngbytes =
+                    Base64.base64decode(json.cells[end-1].outputs[1].data["image/png"])
                 px_size = QuartoNotebookRunner.png_image_metadata(
                     pngbytes;
                     phys_correction = false,
                 )
-                return (; width_px = px_size.width, height_px = px_size.height, logical_size...)
+                return (;
+                    width_px = px_size.width,
+                    height_px = px_size.height,
+                    logical_size...,
+                )
             end
 
             metadata = png_metadata()

--- a/test/testsets/package_integration_hooks.jl
+++ b/test/testsets/package_integration_hooks.jl
@@ -26,31 +26,43 @@ include("../utilities/prelude.jl")
                     "CairoMakie.qmd";
                     showprogress = false,
                 )
-                return json.cells[end-1].outputs[1].metadata["image/png"]
+                logical_size = json.cells[end-1].outputs[1].metadata["image/png"]
+                pngbytes = Base64.base64decode(json.cells[end-1].outputs[1].data["image/png"])
+                px_size = QuartoNotebookRunner.png_image_metadata(
+                    pngbytes;
+                    phys_correction = false,
+                )
+                return (; width_px = px_size.width, height_px = px_size.height, logical_size...)
             end
 
             metadata = png_metadata()
-            @test metadata.width == 4 * 150
-            @test metadata.height == 3 * 150
+            @test metadata.width_px == 4 * 150
+            @test metadata.height_px == 3 * 150
 
             metadata = png_metadata("""
                 fig-width: 8
                 fig-height: 6
                 fig-dpi: 300""")
-            @test metadata.width == 8 * 300
-            @test metadata.height == 6 * 300
+            @test metadata.width_px == 8 * 300
+            @test metadata.height_px == 6 * 300
+            @test metadata.width == 8 * 96
+            @test metadata.height == 6 * 96
 
             metadata = png_metadata("""
                 fig-width: 5
                 fig-dpi: 100""")
-            @test metadata.width == 5 * 100
-            @test metadata.height == round(5 / 4 * 3 * 100)
+            @test metadata.width_px == 5 * 100
+            @test metadata.height_px == round(5 / 4 * 3 * 100)
+            @test metadata.width == 5 * 96
+            @test metadata.height == round(5 / 4 * 3 * 96)
 
             metadata = png_metadata("""
                 fig-height: 5
                 fig-dpi: 100""")
-            @test metadata.height == 5 * 100
-            @test metadata.width == round(5 / 3 * 4 * 100)
+            @test metadata.height_px == 5 * 100
+            @test metadata.width_px == round(5 / 3 * 4 * 100)
+            @test metadata.height == 5 * 96
+            @test metadata.width == round(5 / 3 * 4 * 96)
 
             # we don't want to rely on hardcoding Makie's own default size for our tests
             # but for the dpi-only test we can check that doubling the
@@ -59,8 +71,10 @@ include("../utilities/prelude.jl")
                 fig-dpi: 96""")
             metadata_200dpi = png_metadata("""
                 fig-dpi: 192""")
-            @test 2 * metadata_100dpi.height == metadata_200dpi.height
-            @test 2 * metadata_100dpi.width == metadata_200dpi.width
+            @test 2 * metadata_100dpi.height_px == metadata_200dpi.height_px
+            @test 2 * metadata_100dpi.width_px == metadata_200dpi.width_px
+            @test metadata_100dpi.height == metadata_200dpi.height
+            @test metadata_100dpi.width == metadata_200dpi.width
 
             # same logic for width and height only
             metadata_single = png_metadata("""
@@ -69,6 +83,8 @@ include("../utilities/prelude.jl")
             metadata_double = png_metadata("""
                 fig-width: 6
                 fig-height: 4""")
+            @test 2 * metadata_single.height_px == metadata_double.height_px
+            @test 2 * metadata_single.width_px == metadata_double.width_px
             @test 2 * metadata_single.height == metadata_double.height
             @test 2 * metadata_single.width == metadata_double.width
 

--- a/test/testsets/png_metadata.jl
+++ b/test/testsets/png_metadata.jl
@@ -5,18 +5,47 @@ include("../utilities/prelude.jl")
         read(joinpath(@__DIR__, "..", "assets", "10x15.png")),
     ) == (; width = 10, height = 15)
     @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "10x15.png"));
+        phys_correction = false,
+    ) == (; width = 10, height = 15)
+
+    @test QuartoNotebookRunner.png_image_metadata(
         read(joinpath(@__DIR__, "..", "assets", "15x10.png")),
     ) == (; width = 15, height = 10)
+    @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "15x10.png"));
+        phys_correction = false,
+    ) == (; width = 15, height = 10)
+
     @test QuartoNotebookRunner.png_image_metadata(
         read(joinpath(@__DIR__, "..", "assets", "black_no_dpi.png")),
     ) == (; width = 100, height = 100)
     @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "black_no_dpi.png"));
+        phys_correction = false,
+    ) == (; width = 100, height = 100)
+
+    @test QuartoNotebookRunner.png_image_metadata(
         read(joinpath(@__DIR__, "..", "assets", "black_96_dpi.png")),
     ) == (; width = 100, height = 100)
+    @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "black_96_dpi.png"));
+        phys_correction = false,
+    ) == (; width = 100, height = 100)
+
     @test QuartoNotebookRunner.png_image_metadata(
         read(joinpath(@__DIR__, "..", "assets", "black_300_dpi.png")),
     ) == (; width = 32, height = 32)
     @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "black_300_dpi.png"));
+        phys_correction = false,
+    ) == (; width = 100, height = 100)
+
+    @test QuartoNotebookRunner.png_image_metadata(
         read(joinpath(@__DIR__, "..", "assets", "black_600_dpi.png")),
     ) == (; width = 16, height = 16)
+    @test QuartoNotebookRunner.png_image_metadata(
+        read(joinpath(@__DIR__, "..", "assets", "black_600_dpi.png"));
+        phys_correction = false,
+    ) == (; width = 100, height = 100)
 end

--- a/test/testsets/project_frontmatter.jl
+++ b/test/testsets/project_frontmatter.jl
@@ -20,10 +20,8 @@ include("../utilities/prelude.jl")
             cell = json.cells[6]
             metadata = cell.outputs[1].metadata["image/png"]
             pngbytes = Base64.base64decode(cell.outputs[1].data["image/png"])
-            px_size = QuartoNotebookRunner.png_image_metadata(
-                pngbytes;
-                phys_correction = false,
-            )
+            px_size =
+                QuartoNotebookRunner.png_image_metadata(pngbytes; phys_correction = false)
             @test metadata.width == 600
             @test metadata.height == 450
             @test px_size.width == 625
@@ -43,10 +41,8 @@ include("../utilities/prelude.jl")
             cell = json.cells[6]
             metadata = cell.outputs[1].metadata["image/png"]
             pngbytes = Base64.base64decode(cell.outputs[1].data["image/png"])
-            px_size = QuartoNotebookRunner.png_image_metadata(
-                pngbytes;
-                phys_correction = false,
-            )
+            px_size =
+                QuartoNotebookRunner.png_image_metadata(pngbytes; phys_correction = false)
             @test metadata.width == 600
             @test metadata.height == 450
             @test px_size.width == 625

--- a/test/testsets/project_frontmatter.jl
+++ b/test/testsets/project_frontmatter.jl
@@ -19,8 +19,15 @@ include("../utilities/prelude.jl")
             )
             cell = json.cells[6]
             metadata = cell.outputs[1].metadata["image/png"]
-            @test metadata.width == 625
-            @test metadata.height == 469
+            pngbytes = Base64.base64decode(cell.outputs[1].data["image/png"])
+            px_size = QuartoNotebookRunner.png_image_metadata(
+                pngbytes;
+                phys_correction = false,
+            )
+            @test metadata.width == 600
+            @test metadata.height == 450
+            @test px_size.width == 625
+            @test px_size.height == 469
 
             options_file = "temp_options.json"
             open(options_file, "w") do io
@@ -35,8 +42,15 @@ include("../utilities/prelude.jl")
             )
             cell = json.cells[6]
             metadata = cell.outputs[1].metadata["image/png"]
-            @test metadata.width == 625
-            @test metadata.height == 469
+            pngbytes = Base64.base64decode(cell.outputs[1].data["image/png"])
+            px_size = QuartoNotebookRunner.png_image_metadata(
+                pngbytes;
+                phys_correction = false,
+            )
+            @test metadata.width == 600
+            @test metadata.height == 450
+            @test px_size.width == 625
+            @test px_size.height == 469
 
             close!(server)
         end

--- a/test/utilities/prelude.jl
+++ b/test/utilities/prelude.jl
@@ -2,6 +2,7 @@ using Test
 using Logging
 using QuartoNotebookRunner
 
+import Base64
 import JSON3
 import JSONSchema
 import NodeJS_18_jll


### PR DESCRIPTION
Instead of just changing all the tested metadata values to the same values given figure size (because they don't reflect dpi) I've added tests for both logical and real image size everywhere.