### PR TITLE
Generic Tables.istable support

### DIFF
--- a/src/QuartoNotebookWorker/Project.toml
+++ b/src/QuartoNotebookWorker/Project.toml
@@ -15,7 +15,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -31,7 +30,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [extensions]
 QuartoNotebookWorkerCairoMakieExt = "CairoMakie"
-QuartoNotebookWorkerDataFramesTablesExt = ["DataFrames", "Tables"]
 QuartoNotebookWorkerJSONExt = "JSON"
 QuartoNotebookWorkerLaTeXStringsExt = "LaTeXStrings"
 QuartoNotebookWorkerMakieExt = "Makie"
@@ -43,3 +41,7 @@ QuartoNotebookWorkerRCallExt = "RCall"
 QuartoNotebookWorkerRemoteREPL = "RemoteREPL"
 QuartoNotebookWorkerReviseExt = "Revise"
 QuartoNotebookWorkerSymPyCoreExt = "SymPyCore"
+QuartoNotebookWorkerTablesExt = "Tables"
+
+[compat]
+Tables = "1"

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerDataFramesTablesExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerDataFramesTablesExt.jl
@@ -1,9 +1,0 @@
-module QuartoNotebookWorkerDataFramesTablesExt
-
-import QuartoNotebookWorker
-import DataFrames
-import Tables
-
-QuartoNotebookWorker._ojs_convert(df::DataFrames.AbstractDataFrame) = Tables.rows(df)
-
-end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerJSONExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerJSONExt.jl
@@ -1,12 +1,15 @@
 module QuartoNotebookWorkerJSONExt
 
 import QuartoNotebookWorker
-import JSON
+import JSON: print
 
 function QuartoNotebookWorker._ojs_define(::QuartoNotebookWorker.OJSDefine, kwargs)
     contents = QuartoNotebookWorker.ojs_convert(kwargs)
-    json = JSON.json(Dict("contents" => contents))
-    return HTML("<script type='ojs-define'>$(json)</script>")
+    return HTML() do io
+        print(io, "<script type='ojs-define'>")
+        JSON.print(io, Dict("contents" => contents))
+        print(io, "</script>")
+    end
 end
 
 end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerTablesExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerTablesExt.jl
@@ -1,0 +1,11 @@
+module QuartoNotebookWorkerTablesExt
+
+import QuartoNotebookWorker
+import Tables: istable, rows
+
+# _ojs_convert() returns Tables.rows() iterator
+# for objects supporting Tables.istable() interface
+QuartoNotebookWorker._has_trait(::Val{:table}, obj) = Tables.istable(obj)
+QuartoNotebookWorker._ojs_convert(::Val{:table}, obj) = Tables.rows(obj)
+
+end

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerTablesExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerTablesExt.jl
@@ -3,9 +3,9 @@ module QuartoNotebookWorkerTablesExt
 import QuartoNotebookWorker
 import Tables: istable, rows
 
-# _ojs_convert() returns Tables.rows() iterator
-# for objects supporting Tables.istable() interface
-QuartoNotebookWorker._has_trait(::Val{:table}, obj) = Tables.istable(obj)
-QuartoNotebookWorker._ojs_convert(::Val{:table}, obj) = Tables.rows(obj)
+# _ojs_convert() will use _ojs_rows() to convert objects
+# that support Tables.istable() interface
+QuartoNotebookWorker._istable(::Nothing, obj) = Tables.istable(obj)
+QuartoNotebookWorker._ojs_rows(::Nothing, obj) = Tables.rows(obj)
 
 end

--- a/src/QuartoNotebookWorker/src/ojs_define.jl
+++ b/src/QuartoNotebookWorker/src/ojs_define.jl
@@ -1,12 +1,29 @@
 struct OJSDefine end
 
+"""
+    ojs_define(; kwargs...)
+
+User-facing function that, given a list of `name = object` pairs,
+makes them available to *ObservableJS* by rendering their
+HTML/JavaScript representation.
+"""
 ojs_define(; kwargs...) = _ojs_define(OJSDefine(), kwargs)
 
+# Internal function that implements rendering of the `name = object` pairs.
+# The actual implementation is in the QuartoNotebookWorkerJSONExt extension.
 function _ojs_define(::Any, kwargs)
     @warn "JSON package not available. Please install the JSON.jl package to use ojs_define."
     return nothing
 end
 
+"""
+    ojs_convert(kwargs)
+
+Given an iterator of `name => object` pairs, return a vector of
+`Dict("name" => name, "value" => lowered_object)`, where the `lowered_object`
+(the result of `_ojs_convert(object)`) is the `object` representation
+that supports direct conversion to JSON.
+"""
 ojs_convert(kwargs) = [Dict("name" => k, "value" => _ojs_convert(v)) for (k, v) in kwargs]
 
 # Internal function to check if the object supports a specific trait.

--- a/src/QuartoNotebookWorker/src/ojs_define.jl
+++ b/src/QuartoNotebookWorker/src/ojs_define.jl
@@ -8,4 +8,30 @@ function _ojs_define(::Any, kwargs)
 end
 
 ojs_convert(kwargs) = [Dict("name" => k, "value" => _ojs_convert(v)) for (k, v) in kwargs]
-_ojs_convert(x) = x
+
+# Internal function to check if the object supports a specific trait.
+# QuartoNotebookWorker extensions that implement specific traits
+# should override this function.
+# The fallback implementation reports no trait support.
+_has_trait(trait::Val, obj::Any) = false
+
+# Trait-specific object conversion that is called when the object
+# supports a specific trait (_has_trait(trait, obj) == true).
+# QuartoNotebookWorker extensions that implement specific traits
+# should override this function.
+# The fallback implementation returns the object unchanged.
+_ojs_convert(trait::Val, obj::Any) = obj
+
+# The default object conversion function that is called when
+# there is no more specific _ojs_convert(obj::T)
+function _ojs_convert(obj::Any)
+    # check if the object implements any of the traits supported by extensions
+    if _has_trait(Val(:table), obj)
+        # if QuartoNotebookWorkerTablesExt is active and
+        # obj supports Tables.istable(obj) interface, do table-specific conversion
+        return _ojs_convert(Val(:table), obj)
+    else
+        # no specific trait support, no conversion by default
+        return obj
+    end
+end


### PR DESCRIPTION
At the moment *QuartoNotebookRunner.jl* supports *ojs_define(df::DataFrame)* via the extension that requires both *DataFrames.jl* and *Tables.jl*.
Actually, *Tables.jl* are not necessary to support DataFrames, one can just use *eachrow(df)* instead of *Tables.rows(df)*.

This PR adds `_has_trait(trait, obj)`/`_ojs_convert(trait, obj)` mechanism, and adds `Val(:table)` trait that 
enables *ojs_convert(df)* for all types that support *Tables.table* interface (dropping `DataFrames` dependency).
~~The *Tables.jl* support is moved into the *QuartoNotebookRunner* directly~~:
  * support for tabular data is critical for *ObservableJS*
  * ~~*isrowtable(df)*~~ *istable(df)* is the generic way to check if the type supports *Tables.jl*, it is not possible to do it via the `_ojs_convert()` argument type constraints
  * adding trivial extensions for each of [numerous packages that support Tables.jl](https://github.com/JuliaData/Tables.jl/blob/main/INTEGRATIONS.md) is not reasonable.