### PR TITLE
Check for `juliaup` more robustly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- More robust detection of `juliaup` on user systems [#303]
+
 ## [v0.17.0] - 2025-04-17
 
 ### Changed
@@ -436,3 +440,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#286]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/286
 [#298]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/298
 [#299]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/299
+[#303]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/303

--- a/src/server.jl
+++ b/src/server.jl
@@ -61,13 +61,15 @@ mutable struct File
     end
 end
 
+_has_juliaup() = success(`juliaup --version`) && success(`julia --version`)
+
 function _julia_exe(exeflags)
     # Find the `julia` executable to use for this worker process. If the
     # `juliaup` command is available, we can use plain `julia` if a channel has
     # been provided in the exeflags. The channel exeflag is dropped from the
     # exeflags vector so that it isn't provided twice, the second of which
     # would be treated as a file name.
-    if all(!isnothing, Sys.which.(("juliaup", "julia")))
+    if _has_juliaup()
         indices = findall(startswith("+"), exeflags)
         if isempty(indices)
             quarto_julia = get(ENV, "QUARTO_JULIA", nothing)


### PR DESCRIPTION
`Sys.which` can fail to find a binary if there are permission issues with the file, even if it can run via `run`. This adjusts the way we check for the `juliaup` binary to use `success` instead.