### PR TITLE
Include `cwd` and `projectDir` in notebook options

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -423,6 +423,8 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
     cache_default = get(get(D, file_frontmatter, "execute"), "cache", false)
 
     pandoc_to_default = nothing
+    cwd_default = nothing
+    project_dir_default = nothing
 
     julia_default = get(file_frontmatter, "julia", nothing)
 
@@ -441,6 +443,8 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             daemon = daemon_default,
             params = params_default,
             cache = cache_default,
+            cwd = cwd_default,
+            project_dir = project_dir_default,
         )
     else
         format = get(D, options, "format")
@@ -469,6 +473,9 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
         cli_params = get(options, "params", Dict())
         params_merged = _recursive_merge(params_default, params, cli_params)
 
+        cwd = get(options, "cwd", cwd_default)
+        project_dir = get(options, "projectDir", project_dir_default)
+
         return _options_template(;
             fig_width,
             fig_height,
@@ -481,6 +488,8 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             daemon,
             params = params_merged,
             cache,
+            cwd,
+            project_dir,
         )
     end
 end
@@ -497,6 +506,8 @@ function _options_template(;
     daemon,
     params,
     cache,
+    cwd,
+    project_dir,
 )
     D = Dict{String,Any}
     return D(
@@ -515,6 +526,8 @@ function _options_template(;
             "metadata" => D("julia" => julia),
         ),
         "params" => D(params),
+        "cwd" => cwd,
+        "projectDir" => project_dir,
     )
 end
 

--- a/test/examples/quarto_integration/_quarto.yml
+++ b/test/examples/quarto_integration/_quarto.yml
@@ -1,0 +1,1 @@
+engines: ['julia']

--- a/test/examples/quarto_integration/project_and_cwd.qmd
+++ b/test/examples/quarto_integration/project_and_cwd.qmd
@@ -1,0 +1,13 @@
+```{julia}
+import QuartoNotebookWorker
+
+projectDir = QuartoNotebookWorker.notebook_options()["projectDir"]
+@show projectDir
+nothing
+```
+
+```{julia}
+cwd = QuartoNotebookWorker.notebook_options()["cwd"]
+@show cwd
+nothing
+```

--- a/test/examples/quarto_integration/subfolder/project_and_cwd.qmd
+++ b/test/examples/quarto_integration/subfolder/project_and_cwd.qmd
@@ -1,0 +1,13 @@
+```{julia}
+import QuartoNotebookWorker
+
+projectDir = QuartoNotebookWorker.notebook_options()["projectDir"]
+@show projectDir
+nothing
+```
+
+```{julia}
+cwd = QuartoNotebookWorker.notebook_options()["cwd"]
+@show cwd
+nothing
+```

--- a/test/testsets/quarto_integration/project_and_cwd.jl
+++ b/test/testsets/quarto_integration/project_and_cwd.jl
@@ -1,0 +1,39 @@
+include("../../utilities/prelude.jl")
+
+@testset "quarto includes" begin
+    # TODO: use quarto_jll for integration tests once modern enough versions are available
+    cmd(file) = addenv(
+        `quarto render $file --to md`,
+        "QUARTO_JULIA_PROJECT" => normpath(joinpath(@__DIR__, "..", "..", "..")),
+    )
+    outputfile(file) = splitext(file)[1] * ".md"
+
+    project_dir = normpath(joinpath(@__DIR__, "..", "..", "examples", "quarto_integration"))
+    # for some reason the quarto project inside the normal test folder structure is not
+    # picked up by quarto, so we transfer the files to a separate temp dir first
+    mktempdir() do dir
+        cp(project_dir, dir; force = true)
+        file = joinpath(dir, "project_and_cwd.qmd")
+        file_subfolder = joinpath(dir, "subfolder", "project_and_cwd.qmd")
+
+        run(cmd(file))
+        run(cmd(file_subfolder))
+
+        output = outputfile(file)
+        output_subfolder = outputfile(file_subfolder)
+
+        str_output = read(output, String)
+        @test occursin("cwd = $(repr(dir))", str_output)
+        @test occursin("projectDir = $(repr(dir))", str_output)
+
+        # subfolder has different cwd but same projectDir
+        str_output_subfolder = read(output_subfolder, String)
+        @test occursin("cwd = $(repr(joinpath(dir, "subfolder")))", str_output_subfolder)
+        @test occursin("projectDir = $(repr(dir))", str_output_subfolder)
+
+        rm(output)
+        rm(output_subfolder)
+
+        run(`quarto call engine julia stop`)
+    end
+end


### PR DESCRIPTION
`projectDir` can be used, e.g., to look for files and folders that should live relative to the project root, `cwd` I don't have an immediate use for but it seemed sensible to include it as well. Seemed to me that this might be a robust way to get the intended cwd of a notebook anywhere, as some julia code could have possibly changed it in the meantime.