### PR TITLE
Add link to Quarto Julia docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Fmonthly_downloads%2FQuartoNotebookRunner&query=total_requests&suffix=%2Fmonth&label=Downloads)](https://juliapkgstats.com/pkg/QuartoNotebookRunner)
 [![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Ftotal_downloads%2FQuartoNotebookRunner&query=total_requests&&label=Total%20Downloads)](https://juliapkgstats.com/pkg/QuartoNotebookRunner)
 
+**User documentation:** https://quarto.org/docs/computations/julia.html
 
 > [!NOTE]
 >


### PR DESCRIPTION
The current README.md contains a lot of developer documentation, but no user documentation. I guess we should just link to https://quarto.org/docs/computations/julia.html at the top? Perhaps this link should also be put as URL in the GitHub repo About section?
