### PR TITLE
fix: refresh `QUARTO_PROJECT_ROOT` env var when rendering multiple projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Refresh `QUARTO_PROJECT_ROOT` env var when rendering different projects through the same server [#336]
 - Fix sandbox temp directory leak in `render()` [#399]
 - Fix duplicate YAML keys when Python/R cells have cell options like `echo` [#394]
 - Wrap package hook invocations in try-catch to prevent worker hangs from hook errors [#390]
@@ -495,6 +496,7 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#306]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/306
 [#317]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/317
 [#335]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/335
+[#336]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/336
 [#339]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/339
 [#385]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/385
 [#387]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/387

--- a/src/options.jl
+++ b/src/options.jl
@@ -70,6 +70,7 @@ function _options_template(;
     cache,
     env,
     cwd,
+    project_dir,
 )
     D = Dict{String,Any}
     return D(
@@ -90,6 +91,7 @@ function _options_template(;
         "params" => D(params),
         "env" => env,
         "cwd" => cwd,
+        "projectDir" => project_dir,
     )
 end
 
@@ -133,6 +135,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             cache = cache_default,
             env = Dict{String,Any}(),
             cwd = nothing,
+            project_dir = nothing,
         )
     else
         format = get(D, options, "format")
@@ -163,6 +166,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
         params_merged = _recursive_merge(params_default, params, cli_params)
 
         cwd = get(options, "cwd", nothing)
+        project_dir = get(options, "projectDir", nothing)
 
         return _options_template(;
             fig_width,
@@ -178,6 +182,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             cache,
             env,
             cwd,
+            project_dir,
         )
     end
 end

--- a/src/worker_setup.jl
+++ b/src/worker_setup.jl
@@ -122,6 +122,13 @@ function _exeflags_and_env(options)
     # that the user has not set themselves to show up there.
     quarto_env = Base.byteenv(options["env"])
 
+    # Set QUARTO_PROJECT_ROOT when Quarto provides a projectDir so that
+    # the variable is refreshed for each project in multi-project renders.
+    project_dir = get(options, "projectDir", nothing)
+    if !isnothing(project_dir)
+        push!(quarto_env, "QUARTO_PROJECT_ROOT=$project_dir")
+    end
+
     # Ensure that coverage settings are passed to the worker so that worker
     # code is tracked correctly during tests.
     # Based on https://github.com/JuliaLang/julia/blob/eed18bdf706b7aab15b12f3ba0588e8fafcd4930/base/util.jl#L216-L229.

--- a/test/testsets/quarto_project_root_test.jl
+++ b/test/testsets/quarto_project_root_test.jl
@@ -1,0 +1,62 @@
+@testitem "quarto project root" tags = [:notebook] setup = [RunnerTestSetup] begin
+    import .RunnerTestSetup as RTS
+    import QuartoNotebookRunner as QNR
+
+    mktempdir() do dir
+        projectA = joinpath(dir, "projectA")
+        projectB = joinpath(dir, "projectB")
+        mkpath(projectA)
+        mkpath(projectB)
+
+        qmd = """
+        ---
+        engine: julia
+        ---
+
+        ```{julia}
+        ENV["QUARTO_PROJECT_ROOT"]
+        ```
+        """
+
+        notebook_a = joinpath(projectA, "a.qmd")
+        notebook_b = joinpath(projectB, "b.qmd")
+        write(notebook_a, qmd)
+        write(notebook_b, qmd)
+
+        server = QNR.Server()
+        try
+            buf_a = IOBuffer()
+            QNR.run!(
+                server,
+                notebook_a;
+                options = Dict{String,Any}("projectDir" => projectA),
+                output = buf_a,
+                showprogress = false,
+            )
+            json_a = RTS.JSON3.read(seekstart(buf_a), Any)
+            RTS.validate_notebook(json_a)
+
+            buf_b = IOBuffer()
+            QNR.run!(
+                server,
+                notebook_b;
+                options = Dict{String,Any}("projectDir" => projectB),
+                output = buf_b,
+                showprogress = false,
+            )
+            json_b = RTS.JSON3.read(seekstart(buf_b), Any)
+            RTS.validate_notebook(json_b)
+
+            output_a = json_a["cells"][2]["outputs"][1]["data"]["text/plain"]
+            output_b = json_b["cells"][2]["outputs"][1]["data"]["text/plain"]
+
+            @test contains(output_a, "projectA")
+            @test !contains(output_a, "projectB")
+
+            @test contains(output_b, "projectB")
+            @test !contains(output_b, "projectA")
+        finally
+            QNR.close!(server)
+        end
+    end
+end


### PR DESCRIPTION
Plumb `projectDir` from Quarto's options JSON through `_options_template` in `options.jl` to `_exeflags_and_env` in `worker_setup.jl`, where it's injected into `quarto_env` as `QUARTO_PROJECT_ROOT`. This ensures the env var is refreshed on each `run!` call rather than persisting from the first project rendered.

Server-level test verifies two notebooks rendered through the same server each see their own project root.

Fixes #335