### PR TITLE
feat: support execute-dir option from Quarto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Manifest.toml
 .cache
 !/test/assets/*
 !/src/QuartoNotebookWorker/src/vendor/Manifest.toml
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for Quarto's `execute-dir: project` option to set working directory to project root [#387]
 - Unit tests for QuartoNotebookWorker using TestItemRunner, run in CI before main test suite [#385]
 
 ## [v0.17.4] - 2025-09-26
@@ -478,3 +479,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#335]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/335
 [#339]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/339
 [#385]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/385
+[#387]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/387

--- a/src/QuartoNotebookWorker/src/refresh.jl
+++ b/src/QuartoNotebookWorker/src/refresh.jl
@@ -1,8 +1,7 @@
 function refresh!(path, original_options, options = original_options)
-    # Current directory should always start out as the directory of the
-    # notebook file, which is not necessarily right initially if the parent
-    # process was started from a different directory to the notebook.
-    cd(dirname(path))
+    # Set working directory based on cwd option (from execute-dir) or default
+    # to notebook directory.
+    cd(something(options["cwd"], dirname(path)))
     task_local_storage()[:SOURCE_PATH] = path
 
     # Reset back to the original project environment if it happens to

--- a/src/server.jl
+++ b/src/server.jl
@@ -489,6 +489,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             params = params_default,
             cache = cache_default,
             env = Dict{String,Any}(),
+            cwd = nothing,
         )
     else
         format = get(D, options, "format")
@@ -518,6 +519,8 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
         cli_params = get(options, "params", Dict())
         params_merged = _recursive_merge(params_default, params, cli_params)
 
+        cwd = get(options, "cwd", nothing)
+
         return _options_template(;
             fig_width,
             fig_height,
@@ -531,6 +534,7 @@ function _extract_relevant_options(file_frontmatter::Dict, options::Dict)
             params = params_merged,
             cache,
             env,
+            cwd,
         )
     end
 end
@@ -548,6 +552,7 @@ function _options_template(;
     params,
     cache,
     env,
+    cwd,
 )
     D = Dict{String,Any}
     return D(
@@ -567,6 +572,7 @@ function _options_template(;
         ),
         "params" => D(params),
         "env" => env,
+        "cwd" => cwd,
     )
 end
 

--- a/test/testsets/cwd_option_test.jl
+++ b/test/testsets/cwd_option_test.jl
@@ -1,0 +1,38 @@
+@testitem "cwd option" tags = [:notebook] setup = [RunnerTestSetup] begin
+    import .RunnerTestSetup as RTS
+    import QuartoNotebookRunner as QNR
+
+    mktempdir() do project_root
+        # Create subdirectory with notebook
+        subdir = joinpath(project_root, "docs")
+        mkpath(subdir)
+        notebook = joinpath(subdir, "test.qmd")
+        write(
+            notebook,
+            """
+---
+engine: julia
+---
+
+```{julia}
+pwd()
+```
+""",
+        )
+
+        # Test with cwd = project_root (simulates execute-dir: project)
+        options = Dict{String,Any}("cwd" => project_root)
+        json, server = RTS.run_notebook(notebook; options)
+        RTS.validate_notebook(json)
+
+        # Verify pwd() returned project_root, not subdir
+        cell = json["cells"][2]
+        output = cell["outputs"][1]["data"]["text/plain"]
+        # Check we're not in the docs subdirectory (the key assertion)
+        @test !contains(output, "docs")
+        # Check we got the temp dir basename (handles Windows path escaping)
+        @test contains(output, basename(project_root))
+
+        QNR.close!(server)
+    end
+end


### PR DESCRIPTION
Pass through cwd option from Quarto to set working directory during notebook execution. Enables execute-dir: project in _quarto.yml.