### PR TITLE
fix(hooks): catch errors in package hooks to prevent worker hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Quarto's `execute-dir: project` option to set working directory to project root [#387]
 - Unit tests for QuartoNotebookWorker using TestItemRunner, run in CI before main test suite [#385]
 
+### Fixed
+
+- Wrap package hook invocations in try-catch to prevent worker hangs from hook errors [#390]
+
 ### Changed
 
 - Replace Malt+BSON with custom binary IPC protocol for worker communication [#388]
@@ -487,3 +491,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#385]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/385
 [#387]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/387
 [#388]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/388
+[#390]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/390

--- a/src/QuartoNotebookWorker/src/package_hooks.jl
+++ b/src/QuartoNotebookWorker/src/package_hooks.jl
@@ -1,10 +1,18 @@
 # Package loading/refresh hooks.
 
+function _run_hooks(hooks, hook_type::String)
+    for hook in hooks
+        try
+            Base.@invokelatest hook()
+        catch e
+            @warn "Error in $hook_type hook" hook exception = (e, catch_backtrace())
+        end
+    end
+end
+
 let hooks = Set{Function}()
     global function run_package_loading_hooks()
-        for hook in hooks
-            Base.@invokelatest hook()
-        end
+        _run_hooks(hooks, "package loading")
     end
     global function add_package_loading_hook!(f::Function)
         push!(hooks, f)
@@ -13,9 +21,7 @@ end
 
 let hooks = Set{Function}()
     global function run_package_refresh_hooks()
-        for hook in hooks
-            Base.@invokelatest hook()
-        end
+        _run_hooks(hooks, "package refresh")
     end
     global function add_package_refresh_hook!(f::Function)
         push!(hooks, f)
@@ -27,9 +33,7 @@ end
 
 let hooks = Set{Function}()
     global function run_post_eval_hooks()
-        for hook in hooks
-            Base.@invokelatest hook()
-        end
+        _run_hooks(hooks, "post eval")
     end
     global function add_post_eval_hook!(f::Function)
         push!(hooks, f)
@@ -38,9 +42,7 @@ end
 
 let hooks = Set{Function}()
     global function run_post_error_hooks()
-        for hook in hooks
-            Base.@invokelatest hook()
-        end
+        _run_hooks(hooks, "post error")
     end
     global function add_post_error_hook!(f::Function)
         push!(hooks, f)

--- a/src/QuartoNotebookWorker/test/package_hooks_test.jl
+++ b/src/QuartoNotebookWorker/test/package_hooks_test.jl
@@ -1,0 +1,40 @@
+@testitem "hooks catch errors and continue" begin
+    import QuartoNotebookWorker as QNW
+
+    # Track which hooks ran
+    ran = Ref{Vector{Symbol}}(Symbol[])
+
+    # Hooks run in undefined order (Set), so we just track they all ran
+    hooks = Set{Function}()
+
+    function good_hook_1()
+        push!(ran[], :good1)
+    end
+    function bad_hook()
+        push!(ran[], :bad)
+        error("intentional hook failure")
+    end
+    function good_hook_2()
+        push!(ran[], :good2)
+    end
+
+    push!(hooks, good_hook_1)
+    push!(hooks, bad_hook)
+    push!(hooks, good_hook_2)
+
+    # Should not throw, should warn
+    @test_logs (:warn, r"Error in test hook") QNW._run_hooks(hooks, "test")
+
+    # All hooks should have run despite one failing
+    @test :good1 in ran[]
+    @test :bad in ran[]
+    @test :good2 in ran[]
+    @test length(ran[]) == 3
+end
+
+@testitem "hooks work with empty set" begin
+    import QuartoNotebookWorker as QNW
+
+    # Should not throw on empty hooks
+    QNW._run_hooks(Set{Function}(), "empty")
+end


### PR DESCRIPTION
Wrap all hook invocations in try-catch blocks so a failing hook logs a warning but doesn't prevent other hooks from running or leave the worker in a broken state. Fixes #330.