### PR TITLE
refactor(r): unify R cell handling to match Python pattern

### DIFF
--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerRCallExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerRCallExt.jl
@@ -84,4 +84,15 @@ function __init__()
     end
 end
 
+function QuartoNotebookWorker._r_expr(
+    ::Nothing,
+    code::AbstractString,
+    src::LineNumberNode,
+    nb_mod::Module,
+)
+    quote
+        $RCall.rcopy($RCall.reval($RCall.rparse($code)))
+    end
+end
+
 end

--- a/src/QuartoNotebookWorker/src/QuartoNotebookWorker.jl
+++ b/src/QuartoNotebookWorker/src/QuartoNotebookWorker.jl
@@ -103,6 +103,7 @@ include("ojs_define.jl")
 include("notebook_metadata.jl")
 include("manifest_validation.jl")
 include("python.jl")
+include("r.jl")
 
 # Worker IPC dispatch - routes typed requests from host
 dispatch(::WorkerIPC.ManifestInSyncRequest) = _manifest_in_sync()

--- a/src/QuartoNotebookWorker/src/r.jl
+++ b/src/QuartoNotebookWorker/src/r.jl
@@ -1,0 +1,6 @@
+macro R_str(str)
+    return esc(r_expr(str, __source__, __module__))
+end
+r_expr(code::AbstractString, src::LineNumberNode, mod::Module) =
+    _r_expr(nothing, code, src, mod)
+_r_expr(::Any, code::AbstractString, src, mod) = :(error("`RCall.jl` package not loaded."))

--- a/src/QuartoNotebookWorker/test/pythoncall_test.jl
+++ b/src/QuartoNotebookWorker/test/pythoncall_test.jl
@@ -1,7 +1,7 @@
 @testmodule PythonCallSetup begin
     using PythonCall
 
-    # Exact pattern from wrap_with_python_boilerplate in server.jl
+    # Exact pattern from wrap_with_python_boilerplate in cell_processing.jl
     function wrap_python(code)
         """
         Main.QuartoNotebookWorker.py\"\"\"

--- a/src/cell_processing.jl
+++ b/src/cell_processing.jl
@@ -50,10 +50,9 @@ Wrap code for execution via RCall.
 """
 function wrap_with_r_boilerplate(code)
     """
-    @isdefined(RCall) && RCall isa Module && Base.PkgId(RCall).uuid == Base.UUID("6f49c342-dc21-5d91-9882-a32aef131414") || error("RCall must be imported to execute R code cells with QuartoNotebookRunner")
-    RCall.rcopy(RCall.R\"\"\"
+    Main.QuartoNotebookWorker.R\"\"\"
     $code
-    \"\"\")
+    \"\"\"
     """
 end
 


### PR DESCRIPTION
R cells now use extension-based dispatch like Python:
- Add r.jl with R_str macro and _r_expr fallback
- RCall extension overrides _r_expr when loaded
- Remove hardcoded UUID check from boilerplate