### PR TITLE
perf(precompile): expand workloads for worker and host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expand precompile workloads for worker and host to reduce TTFX [#401]
 - Refactor server internals: explicit FileState state machine, atomic forceclose flag, deduplicated worker creation, resilient server shutdown [#399]
 - Cache worker package environments using Scratch.jl; skip Pkg.develop on subsequent startups for same Julia version [#395]
 - Make strict manifest version checking opt-in via `julia: strict_manifest_versions: true` frontmatter; default now matches Pkg behavior (major.minor only) [#392]
@@ -505,3 +506,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#396]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/396
 [#399]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/399
 [#400]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/400
+[#401]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/401

--- a/src/QuartoNotebookWorker/src/render_io.jl
+++ b/src/QuartoNotebookWorker/src/render_io.jl
@@ -34,7 +34,7 @@ function _io_context(mod::Module, cell_options = Dict{String,Any}(), inline = fa
     return [
         :module => mod,
         :limit => true,
-        :color => Base.have_color,
+        :color => something(Base.have_color, false),
         # This allows a `show` method implementation to check for
         # metadata that may be of relevance to it's rendering. For
         # example, if a `typst` table is rendered with a caption

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -7,6 +7,54 @@ PrecompileTools.@setup_workload begin
         raw_text_chunks(script)
         process_results(results)
 
+        # Exercise host-side binary IPC serialization round-trips.
+        for req in [
+            WorkerIPC.ManifestInSyncRequest(),
+            WorkerIPC.RenderRequest(;
+                code = "1",
+                file = "f.qmd",
+                notebook = "f.qmd",
+                line = 1,
+                cell_options = Dict{String,Any}(),
+            ),
+            WorkerIPC.NotebookInitRequest(;
+                file = "f.qmd",
+                project = ".",
+                options = Dict{String,Any}(),
+                cwd = ".",
+                env_vars = String[],
+            ),
+            WorkerIPC.NotebookCloseRequest(; file = "f.qmd"),
+            WorkerIPC.EvaluateParamsRequest(;
+                file = "f.qmd",
+                params = Dict{String,Any}("x" => 1),
+            ),
+        ]
+            bytes = WorkerIPC._ipc_serialize(req)
+            WorkerIPC._ipc_deserialize(bytes)
+        end
+
+        # Exercise response deserialization.
+        resp = WorkerIPC.RenderResponse(
+            [
+                WorkerIPC.CellResult(
+                    "1",
+                    Dict{String,Any}(),
+                    Dict{String,WorkerIPC.MimeResult}(
+                        "text/plain" =>
+                            WorkerIPC.MimeResult("text/plain", false, UInt8[0x31]),
+                    ),
+                    WorkerIPC.MimeResult[],
+                    "",
+                    nothing,
+                    String[],
+                ),
+            ],
+            false,
+        )
+        bytes = WorkerIPC._ipc_serialize(resp)
+        WorkerIPC._ipc_deserialize(bytes)
+
         server = QuartoNotebookRunner.serve()
         sock = Sockets.connect(server.port)
 


### PR DESCRIPTION
Worker: exercise more render paths (println, @info, vectors), IPC serialize round-trip, explicit hints for main/include_str.

Host: exercise all IPC request/response type serialization.

Fix pre-existing bug: Base.have_color is nothing during precompilation, causing TypeError in error backtrace formatting.

Replaces #341.