### PR TITLE
fix: normalize retina fig-format to png with doubled DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Handle `fig-format: retina` by normalizing it to `png` with doubled `fig-dpi`, matching the behavior of Quarto's Jupyter and knitr backends. This fixes blurry plots with the default HTML settings where `retina` is the default format [#408].
+
 ## [v0.18.0] - 2026-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -522,3 +522,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#403]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/403
 [#404]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/404
 [#407]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/407
+[#408]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/408

--- a/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerCairoMakieExt.jl
+++ b/src/QuartoNotebookWorker/ext/QuartoNotebookWorkerCairoMakieExt.jl
@@ -16,7 +16,7 @@ function configure()
     kwargs[:type] = if fm.fig_format in ("pdf", "svg")
         "svg" # enables both pdf and svg, simpler for backends like typst and latex which prefer one
     else
-        "png" # all other fig formats are bitmaps, "retina" is handled via dpi settings
+        "png"
     end
     CairoMakie.activate!(; kwargs...)
 

--- a/src/QuartoNotebookWorker/src/refresh.jl
+++ b/src/QuartoNotebookWorker/src/refresh.jl
@@ -24,5 +24,16 @@ function _figure_metadata()
     fig_format = rget(options, ("format", "execute", "fig-format"), nothing)
     fig_dpi = rget(options, ("format", "execute", "fig-dpi"), nothing)
 
+    # Quarto's "retina" is not a real image format, it means "png at 2x DPI"
+    # so that images look sharp on high-DPI screens. Normalize it here so all
+    # downstream consumers (CairoMakie, Plots, RCall, ...) just see "png" with
+    # the appropriate DPI value.
+    if fig_format == "retina"
+        fig_format = "png"
+        if fig_dpi !== nothing
+            fig_dpi = fig_dpi * 2
+        end
+    end
+
     return (; fig_width_inch, fig_height_inch, fig_format, fig_dpi)
 end

--- a/src/QuartoNotebookWorker/test/core_test.jl
+++ b/src/QuartoNotebookWorker/test/core_test.jl
@@ -38,6 +38,25 @@ end
         @test fm.fig_dpi == 150
         @test fm.fig_format == "png"
     end
+
+    # Retina normalizes to png with doubled DPI
+    options = Dict{String,Any}(
+        "format" => Dict("execute" => Dict("fig-dpi" => 96, "fig-format" => "retina")),
+    )
+    QNW.NotebookState.with_test_context(; options) do
+        fm = QNW._figure_metadata()
+        @test fm.fig_format == "png"
+        @test fm.fig_dpi == 192
+    end
+
+    # Retina without explicit DPI
+    options =
+        Dict{String,Any}("format" => Dict("execute" => Dict("fig-format" => "retina")))
+    QNW.NotebookState.with_test_context(; options) do
+        fm = QNW._figure_metadata()
+        @test fm.fig_format == "png"
+        @test fm.fig_dpi === nothing
+    end
 end
 
 @testitem "_getproperty" begin


### PR DESCRIPTION
## Summary

- Quarto's `fig-format: retina` is a pseudo-format meaning "png at 2x DPI", and it's the invisible default for all HTML formats. Previously, `retina` was passed through as-is to extensions, so e.g. CairoMakie would render at the base DPI (96 by default), resulting in blurry images on high-DPI screens.
- This PR normalizes `retina` in `_figure_metadata()` to `fig_format = "png"` and `fig_dpi = fig_dpi * 2`, matching how Quarto's Jupyter and knitr backends handle it. All downstream extensions (CairoMakie, Plots, RCall) benefit without needing their own retina handling.

## How these changes were tested

- Added unit tests for retina normalization (with and without explicit DPI) in `core_test.jl`

Created with the help of [Claude Code](https://claude.com/claude-code)