### PR TITLE
Make `CLAUDE.md` just include `@AGENTS.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,3 +530,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#404]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/404
 [#407]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/407
 [#408]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/408
+[#412]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/412

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Remove `CLAUDE.md` symlink to avoid Quarto packaging issues [#412]
+
 ## [v0.18.1] - 2026-03-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+<!--
+
+Include the contents of AGENTS.md
+
+https://code.claude.com/docs/en/claude-code-on-the-web#best-practices
+
+-->
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,1 @@
-<!--
-
-Include the contents of AGENTS.md
-
-https://code.claude.com/docs/en/claude-code-on-the-web#best-practices
-
--->
-
 @AGENTS.md


### PR DESCRIPTION
Same like https://github.com/JuliaLang/julia/pull/60722.

I ran into this installing Quarto from conda-forge with Pixi on Windows (unrelated to Julia).

```
❯ pixi add quarto
Error:   × failed to link quarto-1.9.37-h0e8a320_0.conda
  ├─▶ failed to link 'Library/share/quarto/extension-subtrees/julia-engine/CLAUDE.md'
  ├─▶ could not open source file
  ╰─▶ The system cannot find the file specified. (os error 2)
```

I can also raise this at https://github.com/conda-forge/quarto-feedstock, perhaps a workaround is needed there.

