### PR TITLE
fix(worker): detect REPL modes when cells have `#|` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Shell (`;`), help (`?`), and Pkg (`]`) mode cells now work when the cell has `#|` options [#422]
+
 ### Changed
 
 - Remove `CLAUDE.md` symlink to avoid Quarto packaging issues [#412]
@@ -531,3 +535,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#407]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/407
 [#408]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/408
 [#412]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/412
+[#422]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/422

--- a/src/QuartoNotebookWorker/src/render_code.jl
+++ b/src/QuartoNotebookWorker/src/render_code.jl
@@ -21,35 +21,48 @@ function _helpmode(code::AbstractString, mod::Module)
     end
 end
 
+# The cell options are still part of the code that is sent to the worker, so
+# they have to be dropped, along with any blank lines that separate them from
+# the code, before checking for the REPL mode prefixes.
+function _drop_cell_options(code::AbstractString)
+    lines = collect(eachline(IOBuffer(code); keep = true))
+    is_droppable(line) = startswith(line, "#|") || isempty(strip(line))
+    dropped = something(findfirst(!is_droppable, lines), length(lines) + 1) - 1
+    return join(lines[dropped+1:end]), dropped
+end
+
 function _process_code(
     mod::Module,
     code::AbstractString;
     filename::AbstractString,
     lineno::Integer,
 )
+    code_without_options, dropped_lines = _drop_cell_options(code)
+    lineno_without_options = lineno + dropped_lines
+
     help_regex = r"^\s*\?"
-    if startswith(code, help_regex)
-        code = String(chomp(replace(code, help_regex => ""; count = 1)))
+    if startswith(code_without_options, help_regex)
+        code = String(chomp(replace(code_without_options, help_regex => ""; count = 1)))
         ex = _helpmode(code, mod)
         return Expr(:toplevel, ex)
     end
 
     shell_regex = r"^\s*;"
-    if startswith(code, shell_regex)
-        code = String(chomp(replace(code, shell_regex => ""; count = 1)))
+    if startswith(code_without_options, shell_regex)
+        code = String(chomp(replace(code_without_options, shell_regex => ""; count = 1)))
         ex = :($(Base).@cmd($code))
 
         # Force the line numbering of macroexpansion errors to match the
         # location in the notebook cell where the shell command was
         # written.
-        ex.args[2] = LineNumberNode(lineno, filename)
+        ex.args[2] = LineNumberNode(lineno_without_options, filename)
 
         return Expr(:toplevel, :($(Base).run($ex)), nothing)
     end
 
     pkg_regex = r"^\s*\]"
-    if startswith(code, pkg_regex)
-        code = String(chomp(replace(code, pkg_regex => ""; count = 1)))
+    if startswith(code_without_options, pkg_regex)
+        code = String(chomp(replace(code_without_options, pkg_regex => ""; count = 1)))
         return Expr(:toplevel, :(
             let printed = $(Pkg).REPLMode.PRINTED_REPL_WARNING[]
                 $(Pkg).REPLMode.PRINTED_REPL_WARNING[] = true

--- a/src/QuartoNotebookWorker/test/render_test.jl
+++ b/src/QuartoNotebookWorker/test/render_test.jl
@@ -65,7 +65,8 @@ end
     mod = Module(:TestModCellOptions)
 
     expr = QNW._process_code(mod, "#| echo: true\n?sum"; filename = "test.qmd", lineno = 1)
-    @test contains(string(expr), "helpmode")
+    @test string(expr) ==
+          string(QNW._process_code(mod, "?sum"; filename = "test.qmd", lineno = 1))
 
     expr = QNW._process_code(
         mod,

--- a/src/QuartoNotebookWorker/test/render_test.jl
+++ b/src/QuartoNotebookWorker/test/render_test.jl
@@ -59,6 +59,32 @@ end
     @test length(expr.args) >= 2
 end
 
+@testitem "_process_code repl modes with cell options" begin
+    import QuartoNotebookWorker as QNW
+
+    mod = Module(:TestModCellOptions)
+
+    expr = QNW._process_code(mod, "#| echo: true\n?sum"; filename = "test.qmd", lineno = 1)
+    @test contains(string(expr), "helpmode")
+
+    expr = QNW._process_code(
+        mod,
+        "#| echo: true\n\n#| eval: true\n\n;echo hello";
+        filename = "test.qmd",
+        lineno = 1,
+    )
+    str = string(expr)
+    @test contains(str, "run")
+    @test contains(str, "echo hello")
+    @test expr.args[1].args[2].args[2] == LineNumberNode(5, Symbol("test.qmd"))
+
+    expr =
+        QNW._process_code(mod, "#| echo: true\n]status"; filename = "test.qmd", lineno = 1)
+    str = string(expr)
+    @test contains(str, "@pkg_str")
+    @test contains(str, "status")
+end
+
 @testitem "_transform_output" begin
     import QuartoNotebookWorker as QNW
 


### PR DESCRIPTION
A cell like this failed with a parse error, while the same cell without the option worked fine:

````markdown
```{julia}
#| echo: true
;julia --version
```
````

```
ParseError: ;julia --version
                  └┘ ── invalid operator
```

The cell source arrives in the worker with the `#|` lines still attached, so the `;`, `?` and `]` prefix checks in `_process_code` never matched once a cell had any option set, and the code went down the normal parsing path. Now the option lines (plus any blank lines between them and the code) are dropped before those checks, with the line number for shell command macroexpansion errors offset accordingly.
