### PR TITLE
Release 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.18.2] - 2026-09-02
+
 ### Fixed
 
 - Shell (`;`), help (`?`), and Pkg (`]`) mode cells now work when the cell has `#|` options [#422]
@@ -437,6 +439,7 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [v0.17.4]: https://github.com/PumasAI/QuartoNotebookRunner.jl/releases/tag/v0.17.4
 [v0.18.0]: https://github.com/PumasAI/QuartoNotebookRunner.jl/releases/tag/v0.18.0
 [v0.18.1]: https://github.com/PumasAI/QuartoNotebookRunner.jl/releases/tag/v0.18.1
+[v0.18.2]: https://github.com/PumasAI/QuartoNotebookRunner.jl/releases/tag/v0.18.2
 [#9]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/9
 [#11]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/11
 [#14]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/14

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuartoNotebookRunner"
 uuid = "4c0109c6-14e9-4c88-93f0-2b974d3468f4"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["Michael Hatherly <michael@pumas.ai>", "Julius Krumbiegel <juliusk@pumas.ai>"]
 
 [deps]


### PR DESCRIPTION
Bumps the version to 0.18.2.

Only user-facing change since v0.18.1 is the fix for REPL-mode cells (`;`, `?`, `]`) with `#|` options (#422).