### PR TITLE
fix: support Julia 1.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,9 +90,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.version == '1.6'
 
       # Worker tests
-      # Plots.jl's GR backend uses Julia 1.10+ syntax. Remove it on older
-      # Julia to avoid compile errors; the test is filtered out via tags.
-      - run: julia --project=src/QuartoNotebookWorker/test -e 'using Pkg; Pkg.rm("Plots"; io=devnull)'
+      # Plots.jl's GR backend and CairoMakie.jl's DelaunayTriangulation.jl
+      # dependency use Julia 1.10+ syntax. Remove them on older Julia to avoid
+      # compile errors; those tests are filtered out via tags.
+      - run: julia --project=src/QuartoNotebookWorker/test -e 'using Pkg; Pkg.rm(["Plots", "CairoMakie"]; io=devnull)'
         if: matrix.version == '1.6'
 
       # RCall + Julia 1.12 and above hangs on Windows during temp file cleanup.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,9 @@ jobs:
         version:
           - "1.6"
           - "lts"
+          # `1` tracks the latest stable release, so pin the previous stable
+          # release to keep testing it once `1` moves on.
+          - "1.12"
           - "1"
         os:
           - ubuntu-latest
@@ -92,11 +95,12 @@ jobs:
       - run: julia --project=src/QuartoNotebookWorker/test -e 'using Pkg; Pkg.rm("Plots"; io=devnull)'
         if: matrix.version == '1.6'
 
-      # RCall + Julia 1.12 hangs on Windows during temp file cleanup.
-      # RCall itself only tests lts on Windows. Remove it; tests filtered via tags.
+      # RCall + Julia 1.12 and above hangs on Windows during temp file cleanup.
+      # RCall itself only tests lts on Windows, so keep it there and remove it
+      # from every newer version; tests filtered via tags.
       # See: https://github.com/JuliaInterop/RCall.jl/pull/589
       - run: julia --project=src/QuartoNotebookWorker/test -e 'using Pkg; Pkg.rm("RCall"; io=devnull)'
-        if: matrix.os == 'windows-latest' && matrix.version == '1'
+        if: matrix.os == 'windows-latest' && matrix.version != 'lts'
 
       - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Frontmatter merging no longer warns on Julia 1.13, which deprecates `merge(combine, ::AbstractDict...)` in favour of `mergewith` [#429]
+
 ## [v0.18.2] - 2026-09-02
 
 ### Fixed
@@ -539,3 +543,4 @@ caching is enabled. Delete this folder to clear the cache. [#259]
 [#408]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/408
 [#412]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/412
 [#422]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/422
+[#429]: https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/429

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Frontmatter merging no longer warns on Julia 1.13, which deprecates `merge(combine, ::AbstractDict...)` in favour of `mergewith` [#429]
 
+### Changed
+
+- CI tests Julia 1.13 through the `1` channel and pins 1.12 so the previous stable release stays covered [#429]
+
 ## [v0.18.2] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CI tests Julia 1.13 through the `1` channel and pins 1.12 so the previous stable release stays covered [#429]
+- Worker tests drop `CairoMakie` on Julia 1.6, where its `DelaunayTriangulation` dependency no longer compiles [#429]
 
 ## [v0.18.2] - 2026-09-02
 

--- a/src/QuartoNotebookWorker/test/cairomakie_test.jl
+++ b/src/QuartoNotebookWorker/test/cairomakie_test.jl
@@ -1,4 +1,4 @@
-@testitem "CairoMakie svg format" tags = [:integration] begin
+@testitem "CairoMakie svg format" tags = [:integration, :julia110] begin
     import QuartoNotebookWorker as QNW
     import CairoMakie
 
@@ -18,7 +18,7 @@
     end
 end
 
-@testitem "CairoMakie png format" tags = [:integration] begin
+@testitem "CairoMakie png format" tags = [:integration, :julia110] begin
     import QuartoNotebookWorker as QNW
     import CairoMakie
 
@@ -39,7 +39,7 @@ end
     end
 end
 
-@testitem "Makie extension configures size" tags = [:integration] begin
+@testitem "Makie extension configures size" tags = [:integration, :julia110] begin
     import QuartoNotebookWorker as QNW
     import CairoMakie
     Makie = CairoMakie.Makie
@@ -57,7 +57,7 @@ end
     end
 end
 
-@testitem "CairoMakie dpi affects pixel dimensions" tags = [:integration] begin
+@testitem "CairoMakie dpi affects pixel dimensions" tags = [:integration, :julia110] begin
     import QuartoNotebookWorker as QNW
     import CairoMakie
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -5,7 +5,7 @@
 
 Recursively merge dictionaries, with later values overriding earlier ones.
 """
-_recursive_merge(x::AbstractDict...) = merge(_recursive_merge, x...)
+_recursive_merge(x::AbstractDict...) = mergewith(_recursive_merge, x...)
 _recursive_merge(x...) = x[end]
 
 """

--- a/test/testsets/errors_test.jl
+++ b/test/testsets/errors_test.jl
@@ -42,7 +42,9 @@
     @test count("integer division error", traceback) == 1
     @test count("top-level scope", traceback) == 1
     @test count("errors.qmd:26", traceback) == 1
-    @test count("(repeats 4 times)", traceback) == 1
+    # Julia 1.13 draws repeated stack frames in a box labelled `repeated 4
+    # times` where earlier versions appended `(repeats 4 times)` to the frame.
+    @test count(r"\(repeats 4 times\)|repeated 4 times", traceback) == 1
     @test count("errors.qmd:27", traceback) == 1
 
     cell = cells[14]

--- a/test/testsets/errors_test.jl
+++ b/test/testsets/errors_test.jl
@@ -51,13 +51,16 @@
 
     cell = cells[18]
 
-    outputs = cell["outputs"]
+    # Each failing `show` method reports its own error. Their order follows
+    # `Dict` iteration of the mimetypes, which the hashing of the keys decides,
+    # so sort them here to compare against fixed expectations.
+    outputs = sort(cell["outputs"]; by = output -> output["ename"])
     @test length(outputs) == 4
 
     output = outputs[1]
     @test output["output_type"] == "error"
-    @test output["ename"] == "text/plain showerror"
-    @test length(output["traceback"]) == 11
+    @test output["ename"] == "image/svg+xml showerror"
+    @test length(output["traceback"]) == 9
     @test contains(output["traceback"][end], "multimedia.jl")
 
     output = outputs[2]
@@ -74,8 +77,8 @@
 
     output = outputs[4]
     @test output["output_type"] == "error"
-    @test output["ename"] == "image/svg+xml showerror"
-    @test length(output["traceback"]) == 9
+    @test output["ename"] == "text/plain showerror"
+    @test length(output["traceback"]) == 11
     @test contains(output["traceback"][end], "multimedia.jl")
 
     QNR.close!(server)


### PR DESCRIPTION
Julia 1.13 is out and the `1` channel in CI now installs it. Three things broke under it: frontmatter merging called `merge(combine, ::AbstractDict...)`, which 1.13 deprecates; the error-output assertions depended on the hash order of mimetype `Dict` keys, which 1.13 changed; and 1.13 draws repeated stack frames in a box labelled `repeated 4 times` where earlier versions appended `(repeats 4 times)` to the frame.

- `_recursive_merge` calls `mergewith`, so notebook renders no longer print a deprecation warning. `mergewith` exists back to Julia 1.5, so the 1.6 floor holds
- `errors_test` sorts a cell's error outputs by `ename` and accepts either spelling of the repeated-frame marker. Sorting in the test keeps a sort out of `process_results`, which runs for every cell output
- The version matrix pins 1.12 now that `1` has moved to 1.13, and Windows keys its `RCall` removal on lts instead of on `1`
- CairoMakie joins Plots in being dropped from the 1.6 worker tests, since its `DelaunayTriangulation` dependency now uses syntax 1.6 cannot parse. That is dependency drift rather than a 1.13 problem, included here to get CI green

One thing to know when testing locally: a worker whose frontmatter pins no channel runs the default `juliaup` channel rather than the host Julia, so only `QUARTO_JULIA` or the default channel decides which version the notebooks actually run on.